### PR TITLE
Update AutoCompleteTextViewPackager.java

### DIFF
--- a/android/app/src/main/java/com/autocompletetextview/AutoCompleteTextViewPackager.java
+++ b/android/app/src/main/java/com/autocompletetextview/AutoCompleteTextViewPackager.java
@@ -21,11 +21,6 @@ public class AutoCompleteTextViewPackager implements ReactPackage {
     }
 
     @Override
-    public List<Class<? extends JavaScriptModule>> createJSModules() {
-        return Collections.emptyList();
-    }
-
-    @Override
     public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {
         return Arrays.<ViewManager>asList(
                 new AutoCompleteTextViewManager()


### PR DESCRIPTION
Automatic installation is failing in >0.47 so removed this line.

Related to this - https://github.com/facebook/react-native/releases/tag/v0.47.2

Remove unused createJSModules calls ([ce6fb33](https://github.com/facebook/react-native/commit/ce6fb337a146e6f261f2afb564aa19363774a7a8), [53d5504](https://github.com/facebook/react-native/commit/53d5504f4077bf7fb7cbf7c1edac7e2cbde5c964))