### PR TITLE
Trying to ReactEditText

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+Trying to extend ReactEditText
+
 ### Auto Complete Text View
 
 This is a module for accessing **Native Android AutoCompleteTextView.**

--- a/android/src/main/java/com/reactlibrary/AtTokenizer.java
+++ b/android/src/main/java/com/reactlibrary/AtTokenizer.java
@@ -1,0 +1,77 @@
+package com.reactlibrary;
+
+import android.text.SpannableString;
+import android.text.Spanned;
+import android.text.TextUtils;
+import android.widget.MultiAutoCompleteTextView;
+
+public class AtTokenizer implements MultiAutoCompleteTextView.Tokenizer {
+    private char startSigil = '@';
+    public int findTokenStart(CharSequence text, int cursor) {
+      int i = cursor;
+
+      android.util.Log.v("ReactNative", "findTokenStart, i: " + i);
+
+
+      // hello @Bangalore angaloraloralor goa gao.
+      // hello @Yasir ali. and hi @Dima or @Yasir @Dima @Ali is a match. but this should not match cuz its an email right yasir@blah.edu? cool that didnt match
+      //Move i to next char after first '.'.
+      while (i > 0 && text.charAt(i - 1) != startSigil) {
+        i--;
+      }
+      //Move i past all contiguous spaces after a '.'. OLD
+      while (i < cursor && text.charAt(i) == startSigil) {
+        i++;
+      }
+
+      return i;
+    }
+
+    public int findTokenEnd(CharSequence text, int cursor) {
+      int i = cursor;
+      int len = text.length();
+
+      android.util.Log.v("ReactNative", "findTokenEnd, i: " + i);
+
+      //Find sigil if there.
+      while (i < len) {
+        if (text.charAt(i) == startSigil) {
+          return i;
+        } else {
+          i++;
+        }
+      }
+
+      return len;
+    }
+
+    public CharSequence terminateToken(CharSequence text) {
+      int i = text.length();
+
+      android.util.Log.v("ReactNative", "terminateToken, i: " + i);
+
+      //Backup from the right end of the string until the first non empty. OLD
+      while (i > 0 && text.charAt(i - 1) == startSigil) {
+        i--;
+      }
+
+      //If at a sigil return full string.
+      if (i > 0 && text.charAt(i - 1) == startSigil) {
+        return text;
+      } else {
+        if (text instanceof Spanned) {
+          SpannableString sp = new SpannableString(text);
+          TextUtils.copySpansFrom((Spanned) text,
+                                  0,
+                                  text.length(),
+                                  Object.class,
+                                  sp,
+                                  0);
+          return sp;
+        } else {
+          return text;
+        }
+      }
+    }
+
+}

--- a/android/src/main/java/com/reactlibrary/AutoCompleteTextViewManager.java
+++ b/android/src/main/java/com/reactlibrary/AutoCompleteTextViewManager.java
@@ -1,79 +1,656 @@
-package com.reactlibrary;
-
-import android.content.Context;
-import android.text.Editable;
-import android.text.TextWatcher;
-import android.view.View;
-import android.widget.ArrayAdapter;
-
-import com.facebook.react.bridge.Arguments;
-import com.facebook.react.bridge.ReactContext;
-import com.facebook.react.bridge.ReadableArray;
-import com.facebook.react.bridge.WritableMap;
-import com.facebook.react.uimanager.SimpleViewManager;
-import com.facebook.react.uimanager.ThemedReactContext;
-import com.facebook.react.uimanager.annotations.ReactProp;
-import com.facebook.react.uimanager.events.RCTEventEmitter;
-
-import java.util.ArrayList;
-
 /**
- * Created by rajsuvariya on 7/8/17.
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-public class AutoCompleteTextViewManager extends SimpleViewManager<MyAutoCompleteTextView> {
+package com.reactlibrary;
 
-    Context mContext;
+import android.graphics.PorterDuff;
+import android.graphics.Typeface;
+import android.graphics.drawable.Drawable;
+import android.support.v4.content.ContextCompat;
+import android.text.Editable;
+import android.text.InputFilter;
+import android.text.InputType;
+import android.text.Spannable;
+import android.text.TextWatcher;
+import android.util.TypedValue;
+import android.view.Gravity;
+import android.view.KeyEvent;
+import android.view.View;
+import android.view.inputmethod.EditorInfo;
+import android.widget.TextView;
+import com.facebook.infer.annotation.Assertions;
+import com.facebook.react.bridge.JSApplicationIllegalArgumentException;
+import com.facebook.react.bridge.ReactContext;
+import com.facebook.react.bridge.ReadableArray;
+import com.facebook.react.bridge.ReadableMap;
+import com.facebook.react.common.MapBuilder;
+import com.facebook.react.module.annotations.ReactModule;
+import com.facebook.react.uimanager.BaseViewManager;
+import com.facebook.react.uimanager.LayoutShadowNode;
+import com.facebook.react.uimanager.PixelUtil;
+import com.facebook.react.uimanager.Spacing;
+import com.facebook.react.uimanager.ThemedReactContext;
+import com.facebook.react.uimanager.UIManagerModule;
+import com.facebook.react.uimanager.ViewDefaults;
+import com.facebook.react.uimanager.ViewProps;
+import com.facebook.react.uimanager.annotations.ReactProp;
+import com.facebook.react.uimanager.annotations.ReactPropGroup;
+import com.facebook.react.uimanager.events.EventDispatcher;
+import com.facebook.react.views.imagehelper.ResourceDrawableIdHelper;
+import com.facebook.react.views.scroll.ScrollEvent;
+import com.facebook.react.views.scroll.ScrollEventType;
+import com.facebook.react.views.text.DefaultStyleValuesUtil;
+import com.facebook.react.views.text.ReactFontManager;
+import com.facebook.react.views.text.ReactTextUpdate;
+import com.facebook.react.views.text.TextInlineImageSpan;
+import com.facebook.yoga.YogaConstants;
+import java.lang.reflect.Field;
+import java.util.LinkedList;
+import java.util.Map;
+import javax.annotation.Nullable;
 
-    @Override
-    public String getName() {
-        return "RCTAutoCompleteTextView";
+import java.util.ArrayList;
+import android.widget.ArrayAdapter;
+import android.content.Context;
+
+/**
+ * Manages instances of TextInput.
+ */
+@ReactModule(name = AutoCompleteTextViewManager.REACT_CLASS)
+public class AutoCompleteTextViewManager extends BaseViewManager<MyAutoCompleteTextView, LayoutShadowNode> {
+
+  protected static final String REACT_CLASS = "RCTAutoCompleteTextView";
+
+  private static final int[] SPACING_TYPES = {
+      Spacing.ALL, Spacing.LEFT, Spacing.RIGHT, Spacing.TOP, Spacing.BOTTOM,
+  };
+
+  private static final int FOCUS_TEXT_INPUT = 1;
+  private static final int BLUR_TEXT_INPUT = 2;
+
+  private static final int INPUT_TYPE_KEYBOARD_NUMBERED =
+      InputType.TYPE_CLASS_NUMBER | InputType.TYPE_NUMBER_FLAG_DECIMAL |
+          InputType.TYPE_NUMBER_FLAG_SIGNED;
+  private static final int PASSWORD_VISIBILITY_FLAG = InputType.TYPE_TEXT_VARIATION_VISIBLE_PASSWORD &
+        ~InputType.TYPE_TEXT_VARIATION_PASSWORD;
+  private static final int KEYBOARD_TYPE_FLAGS = INPUT_TYPE_KEYBOARD_NUMBERED |
+            InputType.TYPE_TEXT_VARIATION_EMAIL_ADDRESS |
+            InputType.TYPE_CLASS_TEXT | InputType.TYPE_CLASS_PHONE |
+            PASSWORD_VISIBILITY_FLAG;
+
+  private static final String KEYBOARD_TYPE_EMAIL_ADDRESS = "email-address";
+  private static final String KEYBOARD_TYPE_NUMERIC = "numeric";
+  private static final String KEYBOARD_TYPE_PHONE_PAD = "phone-pad";
+  private static final String KEYBOARD_TYPE_VISIBLE_PASSWORD = "visible-password";
+  private static final InputFilter[] EMPTY_FILTERS = new InputFilter[0];
+  private static final int UNSET = -1;
+
+  Context mContext;
+
+  @Override
+  public String getName() {
+    return REACT_CLASS;
+  }
+
+  @Override
+  public MyAutoCompleteTextView createViewInstance(ThemedReactContext context) {
+    this.mContext = context;
+    final MyAutoCompleteTextView editText = new MyAutoCompleteTextView(context);
+    int inputType = editText.getInputType();
+    editText.setInputType(inputType & (~InputType.TYPE_TEXT_FLAG_MULTI_LINE));
+    editText.setReturnKeyType("done");
+    editText.setTextSize(
+        TypedValue.COMPLEX_UNIT_PX,
+        (int) Math.ceil(PixelUtil.toPixelFromSP(ViewDefaults.FONT_SIZE_SP)));
+
+    // editText.setOnClickListener(new View.OnClickListener() {
+    //     @Override
+    //     public void onClick(View view) {
+    //         MyAutoCompleteTextView v = (MyAutoCompleteTextView) view;
+    //         android.util.Log.v("ReactNative", "focus changed!!!");
+    //         v.requestFocus();
+    //     }
+    // });
+    // editText.setOnFocusChangeListener(new View.OnFocusChangeListener() {
+    //     @Override
+    //     public void onFocusChange(View view, boolean b) {
+    //         MyAutoCompleteTextView v = (MyAutoCompleteTextView) view;
+    //         android.util.Log.v("ReactNative", "focus changed!!!");
+    //         v.requestFocus();
+    //     }
+    // });
+    // editText.setOnClickListener(new View.OnClickListener() {
+    //     @Override
+    //     public void onClick(View view) {
+    //         ((MyAutoCompleteTextView)view).showDropDown();
+    //     }
+    // });
+
+    return editText;
+  }
+
+  @Override
+  public LayoutShadowNode createShadowNodeInstance() {
+    return new ReactTextInputShadowNode();
+  }
+
+  @Override
+  public Class<? extends LayoutShadowNode> getShadowNodeClass() {
+    return ReactTextInputShadowNode.class;
+  }
+
+  @Nullable
+  @Override
+  public Map<String, Object> getExportedCustomBubblingEventTypeConstants() {
+    return MapBuilder.<String, Object>builder()
+        .put(
+            "topSubmitEditing",
+            MapBuilder.of(
+                "phasedRegistrationNames",
+                MapBuilder.of(
+                    "bubbled", "onSubmitEditing", "captured", "onSubmitEditingCapture")))
+        .put(
+            "topEndEditing",
+            MapBuilder.of(
+                "phasedRegistrationNames",
+                MapBuilder.of("bubbled", "onEndEditing", "captured", "onEndEditingCapture")))
+        .put(
+            "topTextInput",
+            MapBuilder.of(
+                "phasedRegistrationNames",
+                MapBuilder.of("bubbled", "onTextInput", "captured", "onTextInputCapture")))
+        .put(
+            "topFocus",
+            MapBuilder.of(
+                "phasedRegistrationNames",
+                MapBuilder.of("bubbled", "onFocus", "captured", "onFocusCapture")))
+        .put(
+            "topBlur",
+            MapBuilder.of(
+                "phasedRegistrationNames",
+                MapBuilder.of("bubbled", "onBlur", "captured", "onBlurCapture")))
+        .put(
+            "topKeyPress",
+            MapBuilder.of(
+                "phasedRegistrationNames",
+                MapBuilder.of("bubbled", "onKeyPress", "captured", "onKeyPressCapture")))
+        .build();
+  }
+
+  @Nullable
+  @Override
+  public Map<String, Object> getExportedCustomDirectEventTypeConstants() {
+    return MapBuilder.<String, Object>builder()
+        .put(ScrollEventType.SCROLL.getJSEventName(), MapBuilder.of("registrationName", "onScroll"))
+        .build();
+  }
+
+  @Override
+  public @Nullable Map<String, Integer> getCommandsMap() {
+    return MapBuilder.of("focusTextInput", FOCUS_TEXT_INPUT, "blurTextInput", BLUR_TEXT_INPUT);
+  }
+
+  @Override
+  public void receiveCommand(
+      MyAutoCompleteTextView reactEditText,
+      int commandId,
+      @Nullable ReadableArray args) {
+    switch (commandId) {
+      case FOCUS_TEXT_INPUT:
+        reactEditText.requestFocusFromJS();
+        break;
+      case BLUR_TEXT_INPUT:
+        reactEditText.clearFocusFromJS();
+        break;
+    }
+  }
+
+  @Override
+  public void updateExtraData(MyAutoCompleteTextView view, Object extraData) {
+    if (extraData instanceof ReactTextUpdate) {
+      ReactTextUpdate update = (ReactTextUpdate) extraData;
+
+      view.setPadding(
+          (int) update.getPaddingLeft(),
+          (int) update.getPaddingTop(),
+          (int) update.getPaddingRight(),
+          (int) update.getPaddingBottom());
+
+      if (update.containsImages()) {
+        Spannable spannable = update.getText();
+        TextInlineImageSpan.possiblyUpdateInlineImageSpans(spannable, view);
+      }
+      view.maybeSetText(update);
+    }
+  }
+
+  @ReactProp(name = ViewProps.FONT_SIZE, defaultFloat = ViewDefaults.FONT_SIZE_SP)
+  public void setFontSize(MyAutoCompleteTextView view, float fontSize) {
+    view.setTextSize(
+        TypedValue.COMPLEX_UNIT_PX,
+        (int) Math.ceil(PixelUtil.toPixelFromSP(fontSize)));
+  }
+
+  @ReactProp(name = ViewProps.FONT_FAMILY)
+  public void setFontFamily(MyAutoCompleteTextView view, String fontFamily) {
+    int style = Typeface.NORMAL;
+    if (view.getTypeface() != null) {
+      style = view.getTypeface().getStyle();
+    }
+    Typeface newTypeface = ReactFontManager.getInstance().getTypeface(
+        fontFamily,
+        style,
+        view.getContext().getAssets());
+    view.setTypeface(newTypeface);
+  }
+
+  /**
+  /* This code was taken from the method setFontWeight of the class ReactTextShadowNode
+  /* TODO: Factor into a common place they can both use
+  */
+  @ReactProp(name = ViewProps.FONT_WEIGHT)
+  public void setFontWeight(MyAutoCompleteTextView view, @Nullable String fontWeightString) {
+    int fontWeightNumeric = fontWeightString != null ?
+            parseNumericFontWeight(fontWeightString) : -1;
+    int fontWeight = UNSET;
+    if (fontWeightNumeric >= 500 || "bold".equals(fontWeightString)) {
+      fontWeight = Typeface.BOLD;
+    } else if ("normal".equals(fontWeightString) ||
+            (fontWeightNumeric != -1 && fontWeightNumeric < 500)) {
+      fontWeight = Typeface.NORMAL;
+    }
+    Typeface currentTypeface = view.getTypeface();
+    if (currentTypeface == null) {
+      currentTypeface = Typeface.DEFAULT;
+    }
+    if (fontWeight != currentTypeface.getStyle()) {
+      view.setTypeface(currentTypeface, fontWeight);
+    }
+  }
+
+  /**
+  /* This code was taken from the method setFontStyle of the class ReactTextShadowNode
+  /* TODO: Factor into a common place they can both use
+  */
+  @ReactProp(name = ViewProps.FONT_STYLE)
+  public void setFontStyle(MyAutoCompleteTextView view, @Nullable String fontStyleString) {
+    int fontStyle = UNSET;
+    if ("italic".equals(fontStyleString)) {
+      fontStyle = Typeface.ITALIC;
+    } else if ("normal".equals(fontStyleString)) {
+      fontStyle = Typeface.NORMAL;
     }
 
-    @Override
-    protected MyAutoCompleteTextView createViewInstance(final ThemedReactContext reactContext) {
-        this.mContext = reactContext;
-        final MyAutoCompleteTextView view = new MyAutoCompleteTextView(reactContext);
-        view.setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View view) {
-                ((MyAutoCompleteTextView)view).showDropDown();
-                ((MyAutoCompleteTextView)view).requestFocus();
-            }
-        });
-        view.setOnFocusChangeListener(new View.OnFocusChangeListener() {
-            @Override
-            public void onFocusChange(View view, boolean b) {
-                ((MyAutoCompleteTextView)view).showDropDown();
-                ((MyAutoCompleteTextView)view).requestFocus();
-            }
-        });
-        view.addTextChangedListener(new TextWatcher() {
-            @Override
-            public void beforeTextChanged(CharSequence charSequence, int i, int i1, int i2) {
-
-            }
-
-            @Override
-            public void onTextChanged(CharSequence charSequence, int i, int i1, int i2) {
-                WritableMap event = Arguments.createMap();
-                event.putString("text", charSequence.toString());
-                // ReactContext reactContext = (ReactContext) view.getContext();
-                reactContext.getJSModule(RCTEventEmitter.class).receiveEvent(
-                        view.getId(),
-                        "topChange",
-                        event);
-            }
-
-            @Override
-            public void afterTextChanged(Editable editable) {
-
-            }
-        });
-        view.setThreshold(1);
-        return view;
-
+    Typeface currentTypeface = view.getTypeface();
+    if (currentTypeface == null) {
+      currentTypeface = Typeface.DEFAULT;
     }
+    if (fontStyle != currentTypeface.getStyle()) {
+      view.setTypeface(currentTypeface, fontStyle);
+    }
+  }
+
+  @ReactProp(name = "selection")
+  public void setSelection(MyAutoCompleteTextView view, @Nullable ReadableMap selection) {
+    if (selection == null) {
+      return;
+    }
+
+    if (selection.hasKey("start") && selection.hasKey("end")) {
+      view.setSelection(selection.getInt("start"), selection.getInt("end"));
+    }
+  }
+
+  @ReactProp(name = "onSelectionChange", defaultBoolean = false)
+  public void setOnSelectionChange(final MyAutoCompleteTextView view, boolean onSelectionChange) {
+    if (onSelectionChange) {
+      view.setSelectionWatcher(new ReactSelectionWatcher(view));
+    } else {
+      view.setSelectionWatcher(null);
+    }
+  }
+
+  @ReactProp(name = "blurOnSubmit")
+  public void setBlurOnSubmit(MyAutoCompleteTextView view, @Nullable Boolean blurOnSubmit) {
+    view.setBlurOnSubmit(blurOnSubmit);
+  }
+
+  @ReactProp(name = "onContentSizeChange", defaultBoolean = false)
+  public void setOnContentSizeChange(final MyAutoCompleteTextView view, boolean onContentSizeChange) {
+    if (onContentSizeChange) {
+      view.setContentSizeWatcher(new ReactContentSizeWatcher(view));
+    } else {
+      view.setContentSizeWatcher(null);
+    }
+  }
+
+  @ReactProp(name = "onScroll", defaultBoolean = false)
+  public void setOnScroll(final MyAutoCompleteTextView view, boolean onScroll) {
+    if (onScroll) {
+      view.setScrollWatcher(new ReactScrollWatcher(view));
+    } else {
+      view.setScrollWatcher(null);
+    }
+  }
+
+  @ReactProp(name = "placeholder")
+  public void setPlaceholder(MyAutoCompleteTextView view, @Nullable String placeholder) {
+    view.setHint(placeholder);
+  }
+
+  @ReactProp(name = "placeholderTextColor", customType = "Color")
+  public void setPlaceholderTextColor(MyAutoCompleteTextView view, @Nullable Integer color) {
+    if (color == null) {
+      view.setHintTextColor(DefaultStyleValuesUtil.getDefaultTextColorHint(view.getContext()));
+    } else {
+      view.setHintTextColor(color);
+    }
+  }
+
+  @ReactProp(name = "selectionColor", customType = "Color")
+  public void setSelectionColor(MyAutoCompleteTextView view, @Nullable Integer color) {
+    if (color == null) {
+      view.setHighlightColor(DefaultStyleValuesUtil.getDefaultTextColorHighlight(view.getContext()));
+    } else {
+      view.setHighlightColor(color);
+    }
+
+    setCursorColor(view, color);
+  }
+
+  private void setCursorColor(MyAutoCompleteTextView view, @Nullable Integer color) {
+    // Evil method that uses reflection because there is no public API to changes
+    // the cursor color programmatically.
+    // Based on http://stackoverflow.com/questions/25996032/how-to-change-programatically-edittext-cursor-color-in-android.
+    try {
+      // Get the original cursor drawable resource.
+      Field cursorDrawableResField = TextView.class.getDeclaredField("mCursorDrawableRes");
+      cursorDrawableResField.setAccessible(true);
+      int drawableResId = cursorDrawableResField.getInt(view);
+
+      // The view has no cursor drawable.
+      if (drawableResId == 0) {
+        return;
+      }
+
+      Drawable drawable = ContextCompat.getDrawable(view.getContext(), drawableResId);
+      if (color != null) {
+        drawable.setColorFilter(color, PorterDuff.Mode.SRC_IN);
+      }
+      Drawable[] drawables = {drawable, drawable};
+
+      // Update the current cursor drawable with the new one.
+      Field editorField = TextView.class.getDeclaredField("mEditor");
+      editorField.setAccessible(true);
+      Object editor = editorField.get(view);
+      Field cursorDrawableField = editor.getClass().getDeclaredField("mCursorDrawable");
+      cursorDrawableField.setAccessible(true);
+      cursorDrawableField.set(editor, drawables);
+    } catch (NoSuchFieldException ex) {
+      // Ignore errors to avoid crashing if these private fields don't exist on modified
+      // or future android versions.
+    } catch (IllegalAccessException ex) {}
+  }
+
+  @ReactProp(name = "caretHidden", defaultBoolean = false)
+  public void setCaretHidden(MyAutoCompleteTextView view, boolean caretHidden) {
+    view.setCursorVisible(!caretHidden);
+  }
+
+  @ReactProp(name = "selectTextOnFocus", defaultBoolean = false)
+  public void setSelectTextOnFocus(MyAutoCompleteTextView view, boolean selectTextOnFocus) {
+    view.setSelectAllOnFocus(selectTextOnFocus);
+  }
+
+  @ReactProp(name = ViewProps.COLOR, customType = "Color")
+  public void setColor(MyAutoCompleteTextView view, @Nullable Integer color) {
+    if (color == null) {
+      view.setTextColor(DefaultStyleValuesUtil.getDefaultTextColor(view.getContext()));
+    } else {
+      view.setTextColor(color);
+    }
+  }
+
+  @ReactProp(name = "underlineColorAndroid", customType = "Color")
+  public void setUnderlineColor(MyAutoCompleteTextView view, @Nullable Integer underlineColor) {
+    // Drawable.mutate() can sometimes crash due to an AOSP bug:
+    // See https://code.google.com/p/android/issues/detail?id=191754 for more info
+    Drawable background = view.getBackground();
+    Drawable drawableToMutate = background.getConstantState() != null ?
+      background.mutate() :
+      background;
+
+    if (underlineColor == null) {
+      drawableToMutate.clearColorFilter();
+    } else {
+      drawableToMutate.setColorFilter(underlineColor, PorterDuff.Mode.SRC_IN);
+    }
+  }
+
+  @ReactProp(name = ViewProps.TEXT_ALIGN)
+  public void setTextAlign(MyAutoCompleteTextView view, @Nullable String textAlign) {
+    if (textAlign == null || "auto".equals(textAlign)) {
+      view.setGravityHorizontal(Gravity.NO_GRAVITY);
+    } else if ("left".equals(textAlign)) {
+      view.setGravityHorizontal(Gravity.LEFT);
+    } else if ("right".equals(textAlign)) {
+      view.setGravityHorizontal(Gravity.RIGHT);
+    } else if ("center".equals(textAlign)) {
+      view.setGravityHorizontal(Gravity.CENTER_HORIZONTAL);
+    } else if ("justify".equals(textAlign)) {
+      // Fallback gracefully for cross-platform compat instead of error
+      view.setGravityHorizontal(Gravity.LEFT);
+    } else {
+      throw new JSApplicationIllegalArgumentException("Invalid textAlign: " + textAlign);
+    }
+  }
+
+  @ReactProp(name = ViewProps.TEXT_ALIGN_VERTICAL)
+  public void setTextAlignVertical(MyAutoCompleteTextView view, @Nullable String textAlignVertical) {
+    if (textAlignVertical == null || "auto".equals(textAlignVertical)) {
+      view.setGravityVertical(Gravity.NO_GRAVITY);
+    } else if ("top".equals(textAlignVertical)) {
+      view.setGravityVertical(Gravity.TOP);
+    } else if ("bottom".equals(textAlignVertical)) {
+      view.setGravityVertical(Gravity.BOTTOM);
+    } else if ("center".equals(textAlignVertical)) {
+      view.setGravityVertical(Gravity.CENTER_VERTICAL);
+    } else {
+      throw new JSApplicationIllegalArgumentException("Invalid textAlignVertical: " + textAlignVertical);
+    }
+  }
+
+  @ReactProp(name = "inlineImageLeft")
+  public void setInlineImageLeft(MyAutoCompleteTextView view, @Nullable String resource) {
+    int id = ResourceDrawableIdHelper.getInstance().getResourceDrawableId(view.getContext(), resource);
+    view.setCompoundDrawablesWithIntrinsicBounds(id, 0, 0, 0);
+  }
+
+  @ReactProp(name = "inlineImagePadding")
+  public void setInlineImagePadding(MyAutoCompleteTextView view, int padding) {
+    view.setCompoundDrawablePadding(padding);
+  }
+
+  @ReactProp(name = "editable", defaultBoolean = true)
+  public void setEditable(MyAutoCompleteTextView view, boolean editable) {
+    view.setEnabled(editable);
+  }
+
+  @ReactProp(name = ViewProps.NUMBER_OF_LINES, defaultInt = 1)
+  public void setNumLines(MyAutoCompleteTextView view, int numLines) {
+    view.setLines(numLines);
+  }
+
+  @ReactProp(name = "maxLength")
+  public void setMaxLength(MyAutoCompleteTextView view, @Nullable Integer maxLength) {
+    InputFilter [] currentFilters = view.getFilters();
+    InputFilter[] newFilters = EMPTY_FILTERS;
+
+    if (maxLength == null) {
+      if (currentFilters.length > 0) {
+        LinkedList<InputFilter> list = new LinkedList<>();
+        for (int i = 0; i < currentFilters.length; i++) {
+          if (!(currentFilters[i] instanceof InputFilter.LengthFilter)) {
+            list.add(currentFilters[i]);
+          }
+        }
+        if (!list.isEmpty()) {
+          newFilters = (InputFilter[]) list.toArray(new InputFilter[list.size()]);
+        }
+      }
+    } else {
+      if (currentFilters.length > 0) {
+        newFilters = currentFilters;
+        boolean replaced = false;
+        for (int i = 0; i < currentFilters.length; i++) {
+          if (currentFilters[i] instanceof InputFilter.LengthFilter) {
+            currentFilters[i] = new InputFilter.LengthFilter(maxLength);
+            replaced = true;
+          }
+        }
+        if (!replaced) {
+          newFilters = new InputFilter[currentFilters.length + 1];
+          System.arraycopy(currentFilters, 0, newFilters, 0, currentFilters.length);
+          currentFilters[currentFilters.length] = new InputFilter.LengthFilter(maxLength);
+        }
+      } else {
+        newFilters = new InputFilter[1];
+        newFilters[0] = new InputFilter.LengthFilter(maxLength);
+      }
+    }
+
+    view.setFilters(newFilters);
+  }
+
+  @ReactProp(name = "autoCorrect")
+  public void setAutoCorrect(MyAutoCompleteTextView view, @Nullable Boolean autoCorrect) {
+    // clear auto correct flags, set SUGGESTIONS or NO_SUGGESTIONS depending on value
+    updateStagedInputTypeFlag(
+        view,
+        InputType.TYPE_TEXT_FLAG_AUTO_CORRECT | InputType.TYPE_TEXT_FLAG_NO_SUGGESTIONS,
+        autoCorrect != null ?
+            (autoCorrect.booleanValue() ?
+                InputType.TYPE_TEXT_FLAG_AUTO_CORRECT : InputType.TYPE_TEXT_FLAG_NO_SUGGESTIONS)
+            : 0);
+  }
+
+  @ReactProp(name = "multiline", defaultBoolean = false)
+  public void setMultiline(MyAutoCompleteTextView view, boolean multiline) {
+    updateStagedInputTypeFlag(
+        view,
+        multiline ? 0 : InputType.TYPE_TEXT_FLAG_MULTI_LINE,
+        multiline ? InputType.TYPE_TEXT_FLAG_MULTI_LINE : 0);
+  }
+
+  @ReactProp(name = "secureTextEntry", defaultBoolean = false)
+  public void setSecureTextEntry(MyAutoCompleteTextView view, boolean password) {
+    updateStagedInputTypeFlag(
+        view,
+        password ? 0 :
+            InputType.TYPE_NUMBER_VARIATION_PASSWORD | InputType.TYPE_TEXT_VARIATION_PASSWORD,
+        password ? InputType.TYPE_TEXT_VARIATION_PASSWORD : 0);
+    checkPasswordType(view);
+  }
+
+  @ReactProp(name = "autoCapitalize")
+  public void setAutoCapitalize(MyAutoCompleteTextView view, int autoCapitalize) {
+    updateStagedInputTypeFlag(
+        view,
+        InputType.TYPE_TEXT_FLAG_CAP_SENTENCES | InputType.TYPE_TEXT_FLAG_CAP_WORDS |
+            InputType.TYPE_TEXT_FLAG_CAP_CHARACTERS,
+        autoCapitalize);
+  }
+
+  @ReactProp(name = "keyboardType")
+  public void setKeyboardType(MyAutoCompleteTextView view, @Nullable String keyboardType) {
+    int flagsToSet = InputType.TYPE_CLASS_TEXT;
+    if (KEYBOARD_TYPE_NUMERIC.equalsIgnoreCase(keyboardType)) {
+      flagsToSet = INPUT_TYPE_KEYBOARD_NUMBERED;
+    } else if (KEYBOARD_TYPE_EMAIL_ADDRESS.equalsIgnoreCase(keyboardType)) {
+      flagsToSet = InputType.TYPE_TEXT_VARIATION_EMAIL_ADDRESS | InputType.TYPE_CLASS_TEXT;
+    } else if (KEYBOARD_TYPE_PHONE_PAD.equalsIgnoreCase(keyboardType)) {
+      flagsToSet = InputType.TYPE_CLASS_PHONE;
+    } else if (KEYBOARD_TYPE_VISIBLE_PASSWORD.equalsIgnoreCase(keyboardType)) {
+      // This will supercede secureTextEntry={false}. If it doesn't, due to the way
+      //  the flags work out, the underlying field will end up a URI-type field.
+      flagsToSet = InputType.TYPE_TEXT_VARIATION_VISIBLE_PASSWORD;
+    }
+    updateStagedInputTypeFlag(
+        view,
+        KEYBOARD_TYPE_FLAGS,
+        flagsToSet);
+    checkPasswordType(view);
+  }
+
+  @ReactProp(name = "returnKeyType")
+  public void setReturnKeyType(MyAutoCompleteTextView view, String returnKeyType) {
+    view.setReturnKeyType(returnKeyType);
+  }
+
+  @ReactProp(name = "disableFullscreenUI", defaultBoolean = false)
+  public void setDisableFullscreenUI(MyAutoCompleteTextView view, boolean disableFullscreenUI) {
+    view.setDisableFullscreenUI(disableFullscreenUI);
+  }
+
+  private static final int IME_ACTION_ID = 0x670;
+
+  @ReactProp(name = "returnKeyLabel")
+  public void setReturnKeyLabel(MyAutoCompleteTextView view, String returnKeyLabel) {
+    view.setImeActionLabel(returnKeyLabel, IME_ACTION_ID);
+  }
+
+  @ReactPropGroup(names = {
+      ViewProps.BORDER_RADIUS,
+      ViewProps.BORDER_TOP_LEFT_RADIUS,
+      ViewProps.BORDER_TOP_RIGHT_RADIUS,
+      ViewProps.BORDER_BOTTOM_RIGHT_RADIUS,
+      ViewProps.BORDER_BOTTOM_LEFT_RADIUS
+  }, defaultFloat = YogaConstants.UNDEFINED)
+  public void setBorderRadius(MyAutoCompleteTextView view, int index, float borderRadius) {
+    if (!YogaConstants.isUndefined(borderRadius)) {
+      borderRadius = PixelUtil.toPixelFromDIP(borderRadius);
+    }
+
+    if (index == 0) {
+      view.setBorderRadius(borderRadius);
+    } else {
+      view.setBorderRadius(borderRadius, index - 1);
+    }
+  }
+
+  @ReactProp(name = "borderStyle")
+  public void setBorderStyle(MyAutoCompleteTextView view, @Nullable String borderStyle) {
+    view.setBorderStyle(borderStyle);
+  }
+
+  @ReactPropGroup(names = {
+      ViewProps.BORDER_WIDTH,
+      ViewProps.BORDER_LEFT_WIDTH,
+      ViewProps.BORDER_RIGHT_WIDTH,
+      ViewProps.BORDER_TOP_WIDTH,
+      ViewProps.BORDER_BOTTOM_WIDTH,
+  }, defaultFloat = YogaConstants.UNDEFINED)
+  public void setBorderWidth(MyAutoCompleteTextView view, int index, float width) {
+    if (!YogaConstants.isUndefined(width)) {
+      width = PixelUtil.toPixelFromDIP(width);
+    }
+    view.setBorderWidth(SPACING_TYPES[index], width);
+  }
+
+  @ReactPropGroup(names = {
+      "borderColor", "borderLeftColor", "borderRightColor", "borderTopColor", "borderBottomColor"
+  }, customType = "Color")
+  public void setBorderColor(MyAutoCompleteTextView view, int index, Integer color) {
+    float rgbComponent = color == null ? YogaConstants.UNDEFINED : (float) ((int)color & 0x00FFFFFF);
+    float alphaComponent = color == null ? YogaConstants.UNDEFINED : (float) ((int)color >>> 24);
+    view.setBorderColor(SPACING_TYPES[index], rgbComponent, alphaComponent);
+  }
 
     @ReactProp(name = "dataSource")
     public void setDataSource(MyAutoCompleteTextView view, ReadableArray array){
@@ -81,27 +658,316 @@ public class AutoCompleteTextViewManager extends SimpleViewManager<MyAutoComplet
         for (Object option : array.toArrayList()){
             optionList.add((String)option);
         }
+        String ret = "";
+        for (int i=0; i<optionList.size(); i++){
+          ret += ">" + optionList.get(i) + "< && ";
+        }
+        android.util.Log.v("ReactNative", "doing set got items: " + ret);
+        android.util.Log.v("ReactNative", "doing set adapter now");
 
-        view.setAdapter(new ArrayAdapter<String>(mContext, android.R.layout.simple_spinner_dropdown_item, optionList));
+        ArrayAdapter<String> aas = new ArrayAdapter<String>(mContext,
+                                                            android.R.layout.simple_spinner_dropdown_item,
+                                                            optionList);
+        view.setAdapter(aas);
+        // view.setTokenizer(new android.widget.MultiAutoCompleteTextView.CommaTokenizer());
+        // view.setTokenizer(new AtTokenizer());
+
+        android.util.Log.v("ReactNative", "finished set adapter");
     }
 
-    @ReactProp(name = "value")
-    public void setValue(MyAutoCompleteTextView view, String value){
-        view.setText(value);
-        if (value!=null) {
-            view.setSelection(value.length());
+    @ReactProp(name = "threshold")
+    public void setThreshold(MyAutoCompleteTextView view, @Nullable Integer threshold) {
+        // we must maintain mThreshold, because threshold can never be set < 1. so we need to get read the threshold prop here and see if its 0, if it is then showDropDown, in the onFocus, onClick
+        if (threshold == null) {
+            android.util.Log.v("ReactNative", "doing set thresh now to null");
+            view.setThreshold(1);
+        } else {
+          android.util.Log.v("ReactNative", "doing set thresh now to value of " + threshold);
+            view.setThreshold(threshold);
         }
     }
 
-    @ReactProp(name = "hint")
-    public void setHint(MyAutoCompleteTextView view, String value){
-        view.setHint(value);
+  @Override
+  protected void onAfterUpdateTransaction(MyAutoCompleteTextView view) {
+    super.onAfterUpdateTransaction(view);
+    view.commitStagedInputType();
+  }
+
+  // Sets the correct password type, since numeric and text passwords have different types
+  private static void checkPasswordType(MyAutoCompleteTextView view) {
+    if ((view.getStagedInputType() & INPUT_TYPE_KEYBOARD_NUMBERED) != 0 &&
+        (view.getStagedInputType() & InputType.TYPE_TEXT_VARIATION_PASSWORD) != 0) {
+      // Text input type is numbered password, remove text password variation, add numeric one
+      updateStagedInputTypeFlag(
+          view,
+          InputType.TYPE_TEXT_VARIATION_PASSWORD,
+          InputType.TYPE_NUMBER_VARIATION_PASSWORD);
+    }
+  }
+
+  /**
+   * This code was taken from the method parseNumericFontWeight of the class ReactTextShadowNode
+   * TODO: Factor into a common place they can both use
+   *
+   * Return -1 if the input string is not a valid numeric fontWeight (100, 200, ..., 900), otherwise
+   * return the weight.
+   */
+  private static int parseNumericFontWeight(String fontWeightString) {
+    // This should be much faster than using regex to verify input and Integer.parseInt
+    return fontWeightString.length() == 3 && fontWeightString.endsWith("00")
+            && fontWeightString.charAt(0) <= '9' && fontWeightString.charAt(0) >= '1' ?
+            100 * (fontWeightString.charAt(0) - '0') : -1;
+  }
+
+  private static void updateStagedInputTypeFlag(
+      MyAutoCompleteTextView view,
+      int flagsToUnset,
+      int flagsToSet) {
+    view.setStagedInputType((view.getStagedInputType() & ~flagsToUnset) | flagsToSet);
+  }
+
+  private class ReactTextInputTextWatcher implements TextWatcher {
+
+    private EventDispatcher mEventDispatcher;
+    private MyAutoCompleteTextView mEditText;
+    private String mPreviousText;
+
+    public ReactTextInputTextWatcher(
+        final ReactContext reactContext,
+        final MyAutoCompleteTextView editText) {
+      mEventDispatcher = reactContext.getNativeModule(UIManagerModule.class).getEventDispatcher();
+      mEditText = editText;
+      mPreviousText = null;
     }
 
-    @ReactProp(name = "showDropDown")
-    public void showDropDown(MyAutoCompleteTextView view, boolean show){
-        if (show){
-            view.showDropDown();
-        }
+    @Override
+    public void beforeTextChanged(CharSequence s, int start, int count, int after) {
+      // Incoming charSequence gets mutated before onTextChanged() is invoked
+      mPreviousText = s.toString();
     }
+
+    @Override
+    public void onTextChanged(CharSequence s, int start, int before, int count) {
+      // Rearranging the text (i.e. changing between singleline and multiline attributes) can
+      // also trigger onTextChanged, call the event in JS only when the text actually changed
+      if (count == 0 && before == 0) {
+        return;
+      }
+
+      Assertions.assertNotNull(mPreviousText);
+      String newText = s.toString().substring(start, start + count);
+      String oldText = mPreviousText.substring(start, start + before);
+      // Don't send same text changes
+      if (count == before && newText.equals(oldText)) {
+        return;
+      }
+
+      // The event that contains the event counter and updates it must be sent first.
+      // TODO: t7936714 merge these events
+      mEventDispatcher.dispatchEvent(
+          new ReactTextChangedEvent(
+              mEditText.getId(),
+              s.toString(),
+              mEditText.incrementAndGetEventCounter()));
+
+      mEventDispatcher.dispatchEvent(
+          new ReactTextInputEvent(
+              mEditText.getId(),
+              newText,
+              oldText,
+              start,
+              start + before));
+    }
+
+    @Override
+    public void afterTextChanged(Editable s) {
+    }
+  }
+
+  @Override
+  protected void addEventEmitters(
+      final ThemedReactContext reactContext,
+      final MyAutoCompleteTextView editText) {
+    editText.addTextChangedListener(new ReactTextInputTextWatcher(reactContext, editText));
+    editText.setOnFocusChangeListener(
+        new View.OnFocusChangeListener() {
+          public void onFocusChange(View v, boolean hasFocus) {
+            EventDispatcher eventDispatcher =
+                reactContext.getNativeModule(UIManagerModule.class).getEventDispatcher();
+            if (hasFocus) {
+              eventDispatcher.dispatchEvent(
+                  new ReactTextInputFocusEvent(
+                      editText.getId()));
+            } else {
+              eventDispatcher.dispatchEvent(
+                  new ReactTextInputBlurEvent(
+                      editText.getId()));
+
+              eventDispatcher.dispatchEvent(
+                  new ReactTextInputEndEditingEvent(
+                      editText.getId(),
+                      editText.getText().toString()));
+            }
+          }
+        });
+
+    editText.setOnEditorActionListener(
+        new TextView.OnEditorActionListener() {
+          @Override
+          public boolean onEditorAction(TextView v, int actionId, KeyEvent keyEvent) {
+            // Any 'Enter' action will do
+            if ((actionId & EditorInfo.IME_MASK_ACTION) > 0 ||
+                actionId == EditorInfo.IME_NULL) {
+              boolean blurOnSubmit = editText.getBlurOnSubmit();
+              boolean isMultiline = ((editText.getInputType() &
+                InputType.TYPE_TEXT_FLAG_MULTI_LINE) != 0);
+
+              // Motivation:
+              // * blurOnSubmit && isMultiline => Clear focus; prevent default behaviour (return true);
+              // * blurOnSubmit && !isMultiline => Clear focus; prevent default behaviour (return true);
+              // * !blurOnSubmit && isMultiline => Perform default behaviour (return false);
+              // * !blurOnSubmit && !isMultiline => Prevent default behaviour (return true).
+              // Additionally we always generate a `submit` event.
+
+              EventDispatcher eventDispatcher =
+                  reactContext.getNativeModule(UIManagerModule.class).getEventDispatcher();
+
+              eventDispatcher.dispatchEvent(
+                  new ReactTextInputSubmitEditingEvent(
+                      editText.getId(),
+                      editText.getText().toString()));
+
+              if (blurOnSubmit) {
+                editText.clearFocus();
+              }
+
+              // Prevent default behavior except when we want it to insert a newline.
+              return blurOnSubmit || !isMultiline;
+            }
+
+            return true;
+          }
+        });
+  }
+
+  private class ReactContentSizeWatcher implements ContentSizeWatcher {
+    private MyAutoCompleteTextView mEditText;
+    private EventDispatcher mEventDispatcher;
+    private int mPreviousContentWidth = 0;
+    private int mPreviousContentHeight = 0;
+
+    public ReactContentSizeWatcher(MyAutoCompleteTextView editText) {
+      mEditText = editText;
+      ReactContext reactContext = (ReactContext) editText.getContext();
+      mEventDispatcher = reactContext.getNativeModule(UIManagerModule.class).getEventDispatcher();
+    }
+
+    @Override
+    public void onLayout() {
+      int contentWidth = mEditText.getWidth();
+      int contentHeight = mEditText.getHeight();
+
+      // Use instead size of text content within EditText when available
+      if (mEditText.getLayout() != null) {
+        contentWidth = mEditText.getCompoundPaddingLeft() + mEditText.getLayout().getWidth() +
+          mEditText.getCompoundPaddingRight();
+        contentHeight = mEditText.getCompoundPaddingTop() + mEditText.getLayout().getHeight() +
+          mEditText.getCompoundPaddingBottom();
+      }
+
+      if (contentWidth != mPreviousContentWidth || contentHeight != mPreviousContentHeight) {
+        mPreviousContentHeight = contentHeight;
+        mPreviousContentWidth = contentWidth;
+
+        mEventDispatcher.dispatchEvent(
+          new ReactContentSizeChangedEvent(
+            mEditText.getId(),
+            PixelUtil.toDIPFromPixel(contentWidth),
+            PixelUtil.toDIPFromPixel(contentHeight)));
+      }
+    }
+  }
+
+  private class ReactSelectionWatcher implements SelectionWatcher {
+
+    private MyAutoCompleteTextView mReactEditText;
+    private EventDispatcher mEventDispatcher;
+    private int mPreviousSelectionStart;
+    private int mPreviousSelectionEnd;
+
+    public ReactSelectionWatcher(MyAutoCompleteTextView editText) {
+      mReactEditText = editText;
+      ReactContext reactContext = (ReactContext) editText.getContext();
+      mEventDispatcher = reactContext.getNativeModule(UIManagerModule.class).getEventDispatcher();
+    }
+
+    @Override
+    public void onSelectionChanged(int start, int end) {
+      // Android will call us back for both the SELECTION_START span and SELECTION_END span in text
+      // To prevent double calling back into js we cache the result of the previous call and only
+      // forward it on if we have new values
+      if (mPreviousSelectionStart != start || mPreviousSelectionEnd != end) {
+        mEventDispatcher.dispatchEvent(
+            new ReactTextInputSelectionEvent(
+                mReactEditText.getId(),
+                start,
+                end
+            ));
+
+        mPreviousSelectionStart = start;
+        mPreviousSelectionEnd = end;
+      }
+    }
+  }
+
+  private class ReactScrollWatcher implements ScrollWatcher {
+
+    private MyAutoCompleteTextView mReactEditText;
+    private EventDispatcher mEventDispatcher;
+    private int mPreviousHoriz;
+    private int mPreviousVert;
+
+    public ReactScrollWatcher(MyAutoCompleteTextView editText) {
+      mReactEditText = editText;
+      ReactContext reactContext = (ReactContext) editText.getContext();
+      mEventDispatcher = reactContext.getNativeModule(UIManagerModule.class).getEventDispatcher();
+    }
+
+    @Override
+    public void onScrollChanged(int horiz, int vert, int oldHoriz, int oldVert) {
+      if (mPreviousHoriz != horiz || mPreviousVert != vert) {
+        ScrollEvent event = ScrollEvent.obtain(
+          mReactEditText.getId(),
+          ScrollEventType.SCROLL,
+          horiz,
+          vert,
+          0f, // can't get x velocity
+          0f, // can't get y velocity
+          0, // can't get content width
+          0, // can't get content height
+          mReactEditText.getWidth(),
+          mReactEditText.getHeight());
+
+        mEventDispatcher.dispatchEvent(event);
+
+        mPreviousHoriz = horiz;
+        mPreviousVert = vert;
+      }
+    }
+  }
+
+  @Override
+  public @Nullable Map getExportedViewConstants() {
+    return MapBuilder.of(
+        "AutoCapitalizationType",
+        MapBuilder.of(
+            "none",
+            0,
+            "characters",
+            InputType.TYPE_TEXT_FLAG_CAP_CHARACTERS,
+            "words",
+            InputType.TYPE_TEXT_FLAG_CAP_WORDS,
+            "sentences",
+            InputType.TYPE_TEXT_FLAG_CAP_SENTENCES));
+  }
 }

--- a/android/src/main/java/com/reactlibrary/ContentSizeWatcher.java
+++ b/android/src/main/java/com/reactlibrary/ContentSizeWatcher.java
@@ -1,0 +1,14 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+package com.reactlibrary;
+
+public interface ContentSizeWatcher {
+  public void onLayout();
+}

--- a/android/src/main/java/com/reactlibrary/MyAutoCompleteTextView.java
+++ b/android/src/main/java/com/reactlibrary/MyAutoCompleteTextView.java
@@ -1,25 +1,723 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
 package com.reactlibrary;
 
 import android.content.Context;
+import android.graphics.Rect;
+import android.graphics.Typeface;
+import android.graphics.drawable.Drawable;
+import android.os.Build;
 import android.text.Editable;
 import android.text.InputType;
+import android.text.SpannableStringBuilder;
+import android.text.Spanned;
 import android.text.TextWatcher;
-
-import com.facebook.react.bridge.Arguments;
+import android.text.TextUtils;
+import android.text.method.KeyListener;
+import android.text.method.QwertyKeyListener;
+import android.text.style.AbsoluteSizeSpan;
+import android.text.style.BackgroundColorSpan;
+import android.text.style.ForegroundColorSpan;
+import android.view.Gravity;
+import android.view.KeyEvent;
+import android.view.MotionEvent;
+import android.view.View;
+import android.view.inputmethod.EditorInfo;
+import android.view.inputmethod.InputConnection;
+import android.view.inputmethod.InputMethodManager;
+import android.widget.EditText;
+import com.facebook.infer.annotation.Assertions;
 import com.facebook.react.bridge.ReactContext;
-import com.facebook.react.bridge.WritableMap;
-import com.facebook.react.uimanager.events.RCTEventEmitter;
+import com.facebook.react.uimanager.UIManagerModule;
+import com.facebook.react.views.text.CustomStyleSpan;
+import com.facebook.react.views.text.ReactTagSpan;
+import com.facebook.react.views.text.ReactTextUpdate;
+import com.facebook.react.views.text.TextInlineImageSpan;
+import com.facebook.react.views.view.ReactViewBackgroundManager;
+import java.util.ArrayList;
+import javax.annotation.Nullable;
 
 /**
- * Created by rajsuvariya on 7/8/17.
+ * A wrapper around the EditText that lets us better control what happens when an EditText gets
+ * focused or blurred, and when to display the soft keyboard and when not to.
+ *
+ * ReactEditTexts have setFocusableInTouchMode set to false automatically because touches on the
+ * EditText are managed on the JS side. This also removes the nasty side effect that EditTexts
+ * have, which is that focus is always maintained on one of the EditTexts.
+ *
+ * The wrapper stops the EditText from triggering *TextChanged events, in the case where JS
+ * has called this explicitly. This is the default behavior on other platforms as well.
+ * VisibleForTesting from {@link TextInputEventsTestCase}.
  */
+// public class MyAutoCompleteTextView extends android.widget.MultiAutoCompleteTextView {
+public class MyAutoCompleteTextView extends android.widget.AutoCompleteTextView {
 
-public class MyAutoCompleteTextView extends android.support.v7.widget.AppCompatAutoCompleteTextView {
+  private final InputMethodManager mInputMethodManager;
+  // This flag is set to true when we set the text of the EditText explicitly. In that case, no
+  // *TextChanged events should be triggered. This is less expensive than removing the text
+  // listeners and adding them back again after the text change is completed.
+  private boolean mIsSettingTextFromJS;
+  // This component is controlled, so we want it to get focused only when JS ask it to do so.
+  // Whenever android requests focus (which it does for random reasons), it will be ignored.
+  private boolean mIsJSSettingFocus;
+  private int mDefaultGravityHorizontal;
+  private int mDefaultGravityVertical;
+  private int mNativeEventCount;
+  private int mMostRecentEventCount;
+  private @Nullable ArrayList<TextWatcher> mListeners;
+  private @Nullable TextWatcherDelegator mTextWatcherDelegator;
+  private int mStagedInputType;
+  private boolean mContainsImages;
+  private @Nullable Boolean mBlurOnSubmit;
+  private boolean mDisableFullscreen;
+  private @Nullable String mReturnKeyType;
+  private @Nullable SelectionWatcher mSelectionWatcher;
+  private @Nullable ContentSizeWatcher mContentSizeWatcher;
+  private @Nullable ScrollWatcher mScrollWatcher;
+  private final InternalKeyListener mKeyListener;
+  private boolean mDetectScrollMovement = false;
 
+  private ReactViewBackgroundManager mReactBackgroundManager;
 
-    public MyAutoCompleteTextView(Context context) {
-        super(context);
-        setInputType(InputType.TYPE_TEXT_FLAG_NO_SUGGESTIONS);
+  private static final KeyListener sKeyListener = QwertyKeyListener.getInstanceForFullKeyboard();
+
+  public MyAutoCompleteTextView(Context context) {
+    super(context);
+    setFocusableInTouchMode(false);
+
+    mReactBackgroundManager = new ReactViewBackgroundManager(this);
+    mInputMethodManager = (InputMethodManager)
+        Assertions.assertNotNull(getContext().getSystemService(Context.INPUT_METHOD_SERVICE));
+    mDefaultGravityHorizontal =
+        getGravity() & (Gravity.HORIZONTAL_GRAVITY_MASK | Gravity.RELATIVE_HORIZONTAL_GRAVITY_MASK);
+    mDefaultGravityVertical = getGravity() & Gravity.VERTICAL_GRAVITY_MASK;
+    mNativeEventCount = 0;
+    mMostRecentEventCount = 0;
+    mIsSettingTextFromJS = false;
+    mIsJSSettingFocus = false;
+    mBlurOnSubmit = null;
+    mDisableFullscreen = false;
+    mListeners = null;
+    mTextWatcherDelegator = null;
+    mStagedInputType = getInputType();
+    mKeyListener = new InternalKeyListener();
+    mScrollWatcher = null;
+
+    setInputType(InputType.TYPE_TEXT_FLAG_NO_SUGGESTIONS);
+  }
+
+  // After the text changes inside an EditText, TextView checks if a layout() has been requested.
+  // If it has, it will not scroll the text to the end of the new text inserted, but wait for the
+  // next layout() to be called. However, we do not perform a layout() after a requestLayout(), so
+  // we need to override isLayoutRequested to force EditText to scroll to the end of the new text
+  // immediately.
+  // TODO: t6408636 verify if we should schedule a layout after a View does a requestLayout()
+  @Override
+  public boolean isLayoutRequested() {
+    return false;
+  }
+
+  @Override
+  protected void onLayout(boolean changed, int left, int top, int right, int bottom) {
+    onContentSizeChange();
+  }
+
+  @Override
+  public boolean onTouchEvent(MotionEvent ev) {
+    switch (ev.getAction()) {
+      case MotionEvent.ACTION_DOWN:
+        mDetectScrollMovement = true;
+        // Disallow parent views to intercept touch events, until we can detect if we should be
+        // capturing these touches or not.
+        this.getParent().requestDisallowInterceptTouchEvent(true);
+        break;
+      case MotionEvent.ACTION_MOVE:
+        if (mDetectScrollMovement) {
+          if (!canScrollVertically(-1) &&
+              !canScrollVertically(1) &&
+              !canScrollHorizontally(-1) &&
+              !canScrollHorizontally(1)) {
+            // We cannot scroll, let parent views take care of these touches.
+            this.getParent().requestDisallowInterceptTouchEvent(false);
+          }
+          mDetectScrollMovement = false;
+        }
+        break;
+    }
+    return super.onTouchEvent(ev);
+  }
+
+  // Consume 'Enter' key events: TextView tries to give focus to the next TextInput, but it can't
+  // since we only allow JS to change focus, which in turn causes TextView to crash.
+  @Override
+  public boolean onKeyUp(int keyCode, KeyEvent event) {
+    if (keyCode == KeyEvent.KEYCODE_ENTER && !isMultiline()) {
+      hideSoftKeyboard();
+      return true;
+    }
+    return super.onKeyUp(keyCode, event);
+  }
+
+  @Override
+  protected void onScrollChanged(int horiz, int vert, int oldHoriz, int oldVert) {
+    super.onScrollChanged(horiz, vert, oldHoriz, oldVert);
+
+    if (mScrollWatcher != null) {
+      mScrollWatcher.onScrollChanged(horiz, vert, oldHoriz, oldVert);
+    }
+  }
+
+  @Override
+  public InputConnection onCreateInputConnection(EditorInfo outAttrs) {
+    ReactContext reactContext = (ReactContext) getContext();
+    InputConnection inputConnection = super.onCreateInputConnection(outAttrs);
+    if (inputConnection != null) {
+      inputConnection = new ReactEditTextInputConnectionWrapper(inputConnection, reactContext, this);
     }
 
+    if (isMultiline() && getBlurOnSubmit()) {
+      // Remove IME_FLAG_NO_ENTER_ACTION to keep the original IME_OPTION
+      outAttrs.imeOptions &= ~EditorInfo.IME_FLAG_NO_ENTER_ACTION;
+    }
+    return inputConnection;
+  }
+
+  @Override
+  public void clearFocus() {
+    setFocusableInTouchMode(false);
+    super.clearFocus();
+    hideSoftKeyboard();
+  }
+
+  @Override
+  public boolean requestFocus(int direction, Rect previouslyFocusedRect) {
+    // Always return true if we are already focused. This is used by android in certain places,
+    // such as text selection.
+    if (isFocused()) {
+      return true;
+    }
+    if (!mIsJSSettingFocus) {
+      return false;
+    }
+    setFocusableInTouchMode(true);
+    boolean focused = super.requestFocus(direction, previouslyFocusedRect);
+    showSoftKeyboard();
+    return focused;
+  }
+
+  @Override
+  public void addTextChangedListener(TextWatcher watcher) {
+    if (mListeners == null) {
+      mListeners = new ArrayList<>();
+      super.addTextChangedListener(getTextWatcherDelegator());
+    }
+
+    mListeners.add(watcher);
+  }
+
+  @Override
+  public void removeTextChangedListener(TextWatcher watcher) {
+    if (mListeners != null) {
+      mListeners.remove(watcher);
+
+      if (mListeners.isEmpty()) {
+        mListeners = null;
+        super.removeTextChangedListener(getTextWatcherDelegator());
+      }
+    }
+  }
+
+  public void setContentSizeWatcher(ContentSizeWatcher contentSizeWatcher) {
+    mContentSizeWatcher = contentSizeWatcher;
+  }
+
+  public void setScrollWatcher(ScrollWatcher scrollWatcher) {
+    mScrollWatcher = scrollWatcher;
+  }
+
+  @Override
+  public void setSelection(int start, int end) {
+    // Skip setting the selection if the text wasn't set because of an out of date value.
+    if (mMostRecentEventCount < mNativeEventCount) {
+      return;
+    }
+
+    super.setSelection(start, end);
+  }
+
+  @Override
+  protected void onSelectionChanged(int selStart, int selEnd) {
+    super.onSelectionChanged(selStart, selEnd);
+    if (mSelectionWatcher != null && hasFocus()) {
+      mSelectionWatcher.onSelectionChanged(selStart, selEnd);
+    }
+  }
+
+  @Override
+  protected void onFocusChanged(
+      boolean focused, int direction, Rect previouslyFocusedRect) {
+    super.onFocusChanged(focused, direction, previouslyFocusedRect);
+    if (focused && mSelectionWatcher != null) {
+      mSelectionWatcher.onSelectionChanged(getSelectionStart(), getSelectionEnd());
+    }
+  }
+
+  public void setSelectionWatcher(SelectionWatcher selectionWatcher) {
+    mSelectionWatcher = selectionWatcher;
+  }
+
+  public void setBlurOnSubmit(@Nullable Boolean blurOnSubmit) {
+    mBlurOnSubmit = blurOnSubmit;
+  }
+
+  public boolean getBlurOnSubmit() {
+    if (mBlurOnSubmit == null) {
+      // Default blurOnSubmit
+      return isMultiline() ? false : true;
+    }
+
+    return mBlurOnSubmit;
+  }
+
+  public void setDisableFullscreenUI(boolean disableFullscreenUI) {
+    mDisableFullscreen = disableFullscreenUI;
+    updateImeOptions();
+  }
+
+  public boolean getDisableFullscreenUI() {
+    return mDisableFullscreen;
+  }
+
+  public void setReturnKeyType(String returnKeyType) {
+    mReturnKeyType = returnKeyType;
+    updateImeOptions();
+  }
+
+  public String getReturnKeyType() {
+    return mReturnKeyType;
+  }
+
+  /*protected*/ int getStagedInputType() {
+    return mStagedInputType;
+  }
+
+  /*package*/ void setStagedInputType(int stagedInputType) {
+    mStagedInputType = stagedInputType;
+  }
+
+  /*package*/ void commitStagedInputType() {
+    if (getInputType() != mStagedInputType) {
+      int selectionStart = getSelectionStart();
+      int selectionEnd = getSelectionEnd();
+      setInputType(mStagedInputType);
+      setSelection(selectionStart, selectionEnd);
+    }
+  }
+
+  @Override
+  public void setInputType(int type) {
+    Typeface tf = super.getTypeface();
+    super.setInputType(type);
+    mStagedInputType = type;
+    // Input type password defaults to monospace font, so we need to re-apply the font
+    super.setTypeface(tf);
+
+    // We override the KeyListener so that all keys on the soft input keyboard as well as hardware
+    // keyboards work. Some KeyListeners like DigitsKeyListener will display the keyboard but not
+    // accept all input from it
+    mKeyListener.setInputType(type);
+    setKeyListener(mKeyListener);
+  }
+
+  // VisibleForTesting from {@link TextInputEventsTestCase}.
+  public void requestFocusFromJS() {
+    mIsJSSettingFocus = true;
+    requestFocus();
+    mIsJSSettingFocus = false;
+  }
+
+  /* package */ void clearFocusFromJS() {
+    clearFocus();
+  }
+
+  // VisibleForTesting from {@link TextInputEventsTestCase}.
+  public int incrementAndGetEventCounter() {
+    return ++mNativeEventCount;
+  }
+
+  // VisibleForTesting from {@link TextInputEventsTestCase}.
+  public void maybeSetText(ReactTextUpdate reactTextUpdate) {
+    if( isSecureText() &&
+        TextUtils.equals(getText(), reactTextUpdate.getText())) {
+      return;
+    }
+
+    // Only set the text if it is up to date.
+    mMostRecentEventCount = reactTextUpdate.getJsEventCounter();
+    if (mMostRecentEventCount < mNativeEventCount) {
+      return;
+    }
+
+    // The current text gets replaced with the text received from JS. However, the spans on the
+    // current text need to be adapted to the new text. Since TextView#setText() will remove or
+    // reset some of these spans even if they are set directly, SpannableStringBuilder#replace() is
+    // used instead (this is also used by the the keyboard implementation underneath the covers).
+    SpannableStringBuilder spannableStringBuilder =
+        new SpannableStringBuilder(reactTextUpdate.getText());
+    manageSpans(spannableStringBuilder);
+    mContainsImages = reactTextUpdate.containsImages();
+    //mIsSettingTextFromJS = true;
+    mIsSettingTextFromJS =false;
+
+    getText().replace(0, length(), spannableStringBuilder);
+
+    mIsSettingTextFromJS = false;
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+      if (getBreakStrategy() != reactTextUpdate.getTextBreakStrategy()) {
+        setBreakStrategy(reactTextUpdate.getTextBreakStrategy());
+      }
+    }
+  }
+
+  /**
+   * Remove and/or add {@link Spanned.SPAN_EXCLUSIVE_EXCLUSIVE} spans, since they should only exist
+   * as long as the text they cover is the same. All other spans will remain the same, since they
+   * will adapt to the new text, hence why {@link SpannableStringBuilder#replace} never removes
+   * them.
+   */
+  private void manageSpans(SpannableStringBuilder spannableStringBuilder) {
+    Object[] spans = getText().getSpans(0, length(), Object.class);
+    for (int spanIdx = 0; spanIdx < spans.length; spanIdx++) {
+      // Remove all styling spans we might have previously set
+      if (ForegroundColorSpan.class.isInstance(spans[spanIdx]) ||
+          BackgroundColorSpan.class.isInstance(spans[spanIdx]) ||
+          AbsoluteSizeSpan.class.isInstance(spans[spanIdx]) ||
+          CustomStyleSpan.class.isInstance(spans[spanIdx]) ||
+          ReactTagSpan.class.isInstance(spans[spanIdx])) {
+        getText().removeSpan(spans[spanIdx]);
+      }
+
+      if ((getText().getSpanFlags(spans[spanIdx]) & Spanned.SPAN_EXCLUSIVE_EXCLUSIVE) !=
+          Spanned.SPAN_EXCLUSIVE_EXCLUSIVE) {
+        continue;
+      }
+      Object span = spans[spanIdx];
+      final int spanStart = getText().getSpanStart(spans[spanIdx]);
+      final int spanEnd = getText().getSpanEnd(spans[spanIdx]);
+      final int spanFlags = getText().getSpanFlags(spans[spanIdx]);
+
+      // Make sure the span is removed from existing text, otherwise the spans we set will be
+      // ignored or it will cover text that has changed.
+      getText().removeSpan(spans[spanIdx]);
+      if (sameTextForSpan(getText(), spannableStringBuilder, spanStart, spanEnd)) {
+        spannableStringBuilder.setSpan(span, spanStart, spanEnd, spanFlags);
+      }
+    }
+  }
+
+  private static boolean sameTextForSpan(
+      final Editable oldText,
+      final SpannableStringBuilder newText,
+      final int start,
+      final int end) {
+    if (start > newText.length() || end > newText.length()) {
+      return false;
+    }
+    for (int charIdx = start; charIdx < end; charIdx++) {
+      if (oldText.charAt(charIdx) != newText.charAt(charIdx)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  private boolean showSoftKeyboard() {
+    return mInputMethodManager.showSoftInput(this, 0);
+  }
+
+  private void hideSoftKeyboard() {
+    mInputMethodManager.hideSoftInputFromWindow(getWindowToken(), 0);
+  }
+
+  private TextWatcherDelegator getTextWatcherDelegator() {
+    if (mTextWatcherDelegator == null) {
+      mTextWatcherDelegator = new TextWatcherDelegator();
+    }
+    return mTextWatcherDelegator;
+  }
+
+  private boolean isMultiline() {
+    return (getInputType() & InputType.TYPE_TEXT_FLAG_MULTI_LINE) != 0;
+  }
+
+  private boolean isSecureText() {
+    return
+      (getInputType() &
+        (InputType.TYPE_NUMBER_VARIATION_PASSWORD |
+          InputType.TYPE_TEXT_VARIATION_PASSWORD))
+      != 0;
+  }
+
+  private void onContentSizeChange() {
+    if (mContentSizeWatcher != null) {
+      mContentSizeWatcher.onLayout();
+    }
+
+    setIntrinsicContentSize();
+  }
+
+  private void setIntrinsicContentSize() {
+    ReactContext reactContext = (ReactContext) getContext();
+    UIManagerModule uiManager = reactContext.getNativeModule(UIManagerModule.class);
+    final ReactTextInputLocalData localData = new ReactTextInputLocalData(this);
+    uiManager.setViewLocalData(getId(), localData);
+  }
+
+  /* package */ void setGravityHorizontal(int gravityHorizontal) {
+    if (gravityHorizontal == 0) {
+      gravityHorizontal = mDefaultGravityHorizontal;
+    }
+    setGravity(
+        (getGravity() & ~Gravity.HORIZONTAL_GRAVITY_MASK &
+            ~Gravity.RELATIVE_HORIZONTAL_GRAVITY_MASK) | gravityHorizontal);
+  }
+
+  /* package */ void setGravityVertical(int gravityVertical) {
+    if (gravityVertical == 0) {
+      gravityVertical = mDefaultGravityVertical;
+    }
+    setGravity((getGravity() & ~Gravity.VERTICAL_GRAVITY_MASK) | gravityVertical);
+  }
+
+  private void updateImeOptions() {
+    // Default to IME_ACTION_DONE
+    int returnKeyFlag = EditorInfo.IME_ACTION_DONE;
+    if (mReturnKeyType != null) {
+      switch (mReturnKeyType) {
+        case "go":
+          returnKeyFlag = EditorInfo.IME_ACTION_GO;
+          break;
+        case "next":
+          returnKeyFlag = EditorInfo.IME_ACTION_NEXT;
+          break;
+        case "none":
+          returnKeyFlag = EditorInfo.IME_ACTION_NONE;
+          break;
+        case "previous":
+          returnKeyFlag = EditorInfo.IME_ACTION_PREVIOUS;
+          break;
+        case "search":
+          returnKeyFlag = EditorInfo.IME_ACTION_SEARCH;
+          break;
+        case "send":
+          returnKeyFlag = EditorInfo.IME_ACTION_SEND;
+          break;
+        case "done":
+          returnKeyFlag = EditorInfo.IME_ACTION_DONE;
+          break;
+      }
+    }
+
+    if (mDisableFullscreen) {
+      setImeOptions(returnKeyFlag | EditorInfo.IME_FLAG_NO_FULLSCREEN);
+    } else {
+      setImeOptions(returnKeyFlag);
+    }
+  }
+
+  @Override
+  protected boolean verifyDrawable(Drawable drawable) {
+    if (mContainsImages) {
+      Spanned text = getText();
+      TextInlineImageSpan[] spans = text.getSpans(0, text.length(), TextInlineImageSpan.class);
+      for (TextInlineImageSpan span : spans) {
+        if (span.getDrawable() == drawable) {
+          return true;
+        }
+      }
+    }
+    return super.verifyDrawable(drawable);
+  }
+
+  @Override
+  public void invalidateDrawable(Drawable drawable) {
+    if (mContainsImages) {
+      Spanned text = getText();
+      TextInlineImageSpan[] spans = text.getSpans(0, text.length(), TextInlineImageSpan.class);
+      for (TextInlineImageSpan span : spans) {
+        if (span.getDrawable() == drawable) {
+          invalidate();
+        }
+      }
+    }
+    super.invalidateDrawable(drawable);
+  }
+
+  @Override
+  public void onDetachedFromWindow() {
+    super.onDetachedFromWindow();
+    if (mContainsImages) {
+      Spanned text = getText();
+      TextInlineImageSpan[] spans = text.getSpans(0, text.length(), TextInlineImageSpan.class);
+      for (TextInlineImageSpan span : spans) {
+        span.onDetachedFromWindow();
+      }
+    }
+  }
+
+  @Override
+  public void onStartTemporaryDetach() {
+    super.onStartTemporaryDetach();
+    if (mContainsImages) {
+      Spanned text = getText();
+      TextInlineImageSpan[] spans = text.getSpans(0, text.length(), TextInlineImageSpan.class);
+      for (TextInlineImageSpan span : spans) {
+        span.onStartTemporaryDetach();
+      }
+    }
+  }
+
+  @Override
+  public void onAttachedToWindow() {
+    super.onAttachedToWindow();
+    if (mContainsImages) {
+      Spanned text = getText();
+      TextInlineImageSpan[] spans = text.getSpans(0, text.length(), TextInlineImageSpan.class);
+      for (TextInlineImageSpan span : spans) {
+        span.onAttachedToWindow();
+      }
+    }
+  }
+
+  @Override
+  public void onFinishTemporaryDetach() {
+    super.onFinishTemporaryDetach();
+    if (mContainsImages) {
+      Spanned text =  getText();
+      TextInlineImageSpan[] spans = text.getSpans(0, text.length(), TextInlineImageSpan.class);
+      for (TextInlineImageSpan span : spans) {
+        span.onFinishTemporaryDetach();
+      }
+    }
+  }
+
+  @Override
+  public void setBackgroundColor(int color) {
+    mReactBackgroundManager.setBackgroundColor(color);
+  }
+
+  public void setBorderWidth(int position, float width) {
+    mReactBackgroundManager.setBorderWidth(position, width);
+  }
+
+  public void setBorderColor(int position, float color, float alpha) {
+    mReactBackgroundManager.setBorderColor(position, color, alpha);
+  }
+
+  public void setBorderRadius(float borderRadius) {
+    mReactBackgroundManager.setBorderRadius(borderRadius);
+  }
+
+  public void setBorderRadius(float borderRadius, int position) {
+    mReactBackgroundManager.setBorderRadius(borderRadius, position);
+  }
+
+  public void setBorderStyle(@Nullable String style) {
+    mReactBackgroundManager.setBorderStyle(style);
+  }
+
+  /**
+   * This class will redirect *TextChanged calls to the listeners only in the case where the text
+   * is changed by the user, and not explicitly set by JS.
+   */
+  private class TextWatcherDelegator implements TextWatcher {
+    @Override
+    public void beforeTextChanged(CharSequence s, int start, int count, int after) {
+      if (!mIsSettingTextFromJS && mListeners != null) {
+        for (TextWatcher listener : mListeners) {
+          listener.beforeTextChanged(s, start, count, after);
+        }
+      }
+    }
+
+    @Override
+    public void onTextChanged(CharSequence s, int start, int before, int count) {
+      if (!mIsSettingTextFromJS && mListeners != null) {
+        for (TextWatcher listener : mListeners) {
+          listener.onTextChanged(s, start, before, count);
+        }
+      }
+
+      onContentSizeChange();
+    }
+
+    @Override
+    public void afterTextChanged(Editable s) {
+      if (!mIsSettingTextFromJS && mListeners != null) {
+        for (TextWatcher listener : mListeners) {
+          listener.afterTextChanged(s);
+        }
+      }
+    }
+  }
+
+  /*
+   * This class is set as the KeyListener for the underlying TextView
+   * It does two things
+   *  1) Provides the same answer to getInputType() as the real KeyListener would have which allows
+   *     the proper keyboard to pop up on screen
+   *  2) Permits all keyboard input through
+   */
+  private static class InternalKeyListener implements KeyListener {
+
+    private int mInputType = 0;
+
+    public InternalKeyListener() {
+    }
+
+    public void setInputType(int inputType) {
+      mInputType = inputType;
+    }
+
+    /*
+     * getInputType will return whatever value is passed in.  This will allow the proper keyboard
+     * to be shown on screen but without the actual filtering done by other KeyListeners
+     */
+    @Override
+    public int getInputType() {
+      return mInputType;
+    }
+
+    /*
+     * All overrides of key handling defer to the underlying KeyListener which is shared by all
+     * ReactEditText instances.  It will basically allow any/all keyboard input whether from
+     * physical keyboard or from soft input.
+     */
+    @Override
+    public boolean onKeyDown(View view, Editable text, int keyCode, KeyEvent event) {
+      return sKeyListener.onKeyDown(view, text, keyCode, event);
+    }
+
+    @Override
+    public boolean onKeyUp(View view, Editable text, int keyCode, KeyEvent event) {
+      return sKeyListener.onKeyUp(view, text, keyCode, event);
+    }
+
+    @Override
+    public boolean onKeyOther(View view, Editable text, KeyEvent event) {
+      return sKeyListener.onKeyOther(view, text, event);
+    }
+
+    @Override
+    public void clearMetaKeyState(View view, Editable content, int states) {
+      sKeyListener.clearMetaKeyState(view, content, states);
+    }
+  }
 }

--- a/android/src/main/java/com/reactlibrary/MyAutoCompleteTextView.java
+++ b/android/src/main/java/com/reactlibrary/MyAutoCompleteTextView.java
@@ -373,8 +373,7 @@ public class MyAutoCompleteTextView extends android.widget.AutoCompleteTextView 
         new SpannableStringBuilder(reactTextUpdate.getText());
     manageSpans(spannableStringBuilder);
     mContainsImages = reactTextUpdate.containsImages();
-    //mIsSettingTextFromJS = true;
-    mIsSettingTextFromJS =false;
+    mIsSettingTextFromJS = true;
 
     getText().replace(0, length(), spannableStringBuilder);
 

--- a/android/src/main/java/com/reactlibrary/ReactContentSizeChangedEvent.java
+++ b/android/src/main/java/com/reactlibrary/ReactContentSizeChangedEvent.java
@@ -1,0 +1,57 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+package com.reactlibrary;
+
+import com.facebook.react.bridge.Arguments;
+import com.facebook.react.bridge.WritableMap;
+import com.facebook.react.uimanager.events.Event;
+import com.facebook.react.uimanager.events.RCTEventEmitter;
+
+/**
+ * Event emitted by EditText native view when content size changes.
+ */
+public class ReactContentSizeChangedEvent extends Event<ReactTextChangedEvent> {
+
+  public static final String EVENT_NAME = "topContentSizeChange";
+
+  private float mContentWidth;
+  private float mContentHeight;
+
+  public ReactContentSizeChangedEvent(
+    int viewId,
+    float contentSizeWidth,
+    float contentSizeHeight) {
+    super(viewId);
+    mContentWidth = contentSizeWidth;
+    mContentHeight = contentSizeHeight;
+  }
+
+  @Override
+  public String getEventName() {
+    return EVENT_NAME;
+  }
+
+  @Override
+  public void dispatch(RCTEventEmitter rctEventEmitter) {
+    rctEventEmitter.receiveEvent(getViewTag(), getEventName(), serializeEventData());
+  }
+
+  private WritableMap serializeEventData() {
+    WritableMap eventData = Arguments.createMap();
+
+    WritableMap contentSize = Arguments.createMap();
+    contentSize.putDouble("width", mContentWidth);
+    contentSize.putDouble("height", mContentHeight);
+    eventData.putMap("contentSize", contentSize);
+
+    eventData.putInt("target", getViewTag());
+    return eventData;
+  }
+}

--- a/android/src/main/java/com/reactlibrary/ReactEditTextInputConnectionWrapper.java
+++ b/android/src/main/java/com/reactlibrary/ReactEditTextInputConnectionWrapper.java
@@ -1,0 +1,164 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+package com.reactlibrary;
+
+import javax.annotation.Nullable;
+
+import android.view.KeyEvent;
+import android.view.inputmethod.EditorInfo;
+import android.view.inputmethod.InputConnection;
+import android.view.inputmethod.InputConnectionWrapper;
+import com.facebook.react.bridge.ReactContext;
+import com.facebook.react.uimanager.UIManagerModule;
+import com.facebook.react.uimanager.events.EventDispatcher;
+
+/**
+ * A class to implement the TextInput 'onKeyPress' API on android for soft keyboards.
+ * It is instantiated in {@link MyAutoCompleteTextView#onCreateInputConnection(EditorInfo)}.
+ *
+ * Android IMEs interface with EditText views through the {@link InputConnection} interface,
+ * so any observable change in state of the EditText via the soft-keyboard, should be a side effect of
+ * one or more of the methods in {@link InputConnectionWrapper}.
+ *
+ * {@link InputConnection#setComposingText(CharSequence, int)} is used to set the composing region
+ * (the underlined text) in the {@link android.widget.EditText} view, i.e. when React Native's
+ * TextInput has the property 'autoCorrect' set to true. When text is being composed in the composing
+ * state within the EditText, each key press will result in a call to
+ * {@link InputConnection#setComposingText(CharSequence, int)} with a CharSequence argument equal to
+ * that of the entire composing region, rather than a single character diff.
+ * We can reason about the keyPress based on the resultant cursor position changes of the EditText after
+ * applying this change. For example if the cursor moved backwards by one character when composing,
+ * it's likely it was a delete; if it moves forward by a character, likely to be a key press of that character.
+ *
+ * IMEs can also call {@link InputConnection#beginBatchEdit()} to signify a batch of operations. One
+ * such example is committing a word currently in composing state with the press of the space key.
+ * It is IME dependent but the stock Android keyboard behavior seems to be to commit the currently composing
+ * text with {@link InputConnection#setComposingText(CharSequence, int)} and commits a space character
+ * with a separate call to {@link InputConnection#setComposingText(CharSequence, int)}.
+ * Here we chose to emit the last input of a batch edit as that tends to be the user input, but
+ * it's completely arbitrary.
+ *
+ * Another function of this class is to detect backspaces when the cursor at the beginning of the
+ * {@link android.widget.EditText}, i.e no text is deleted.
+ *
+ * N.B. this class is only applicable for soft keyboards behavior. For hardware keyboards
+ * {@link android.view.View#onKeyDown(int, KeyEvent)} can be overridden to obtain the keycode of the
+ * key pressed.
+ */
+class ReactEditTextInputConnectionWrapper extends InputConnectionWrapper {
+  public static final String NEWLINE_RAW_VALUE = "\n";
+  public static final String BACKSPACE_KEY_VALUE = "Backspace";
+  public static final String ENTER_KEY_VALUE = "Enter";
+
+  private MyAutoCompleteTextView mEditText;
+  private EventDispatcher mEventDispatcher;
+  private boolean mIsBatchEdit;
+  private @Nullable String mKey = null;
+
+  public ReactEditTextInputConnectionWrapper(
+      InputConnection target,
+      final ReactContext reactContext,
+      final MyAutoCompleteTextView editText
+  ) {
+    super(target, false);
+    mEventDispatcher = reactContext.getNativeModule(UIManagerModule.class).getEventDispatcher();
+    mEditText = editText;
+  }
+
+  @Override
+  public boolean beginBatchEdit() {
+    mIsBatchEdit = true;
+    return super.beginBatchEdit();
+  }
+
+  @Override
+  public boolean endBatchEdit() {
+    mIsBatchEdit = false;
+    if (mKey != null) {
+      dispatchKeyEvent(mKey);
+      mKey = null;
+    }
+    return super.endBatchEdit();
+  }
+
+  @Override
+  public boolean setComposingText(CharSequence text, int newCursorPosition) {
+    int previousSelectionStart = mEditText.getSelectionStart();
+    int previousSelectionEnd = mEditText.getSelectionEnd();
+    String key;
+    boolean consumed = super.setComposingText(text, newCursorPosition);
+    int currentSelectionStart = mEditText.getSelectionStart();
+    boolean noPreviousSelection = previousSelectionStart == previousSelectionEnd;
+    boolean cursorDidNotMove = currentSelectionStart == previousSelectionStart;
+    boolean cursorMovedBackwardsOrAtBeginningOfInput =
+        (currentSelectionStart < previousSelectionStart) || currentSelectionStart <= 0;
+    if (cursorMovedBackwardsOrAtBeginningOfInput || (!noPreviousSelection && cursorDidNotMove)) {
+      key = BACKSPACE_KEY_VALUE;
+    } else {
+      key = String.valueOf(mEditText.getText().charAt(currentSelectionStart - 1));
+    }
+    dispatchKeyEventOrEnqueue(key);
+    return consumed;
+  }
+
+  @Override
+  public boolean commitText(CharSequence text, int newCursorPosition) {
+    String key = text.toString();
+    // Assume not a keyPress if length > 1
+    if (key.length() <= 1) {
+      if (key.equals("")) {
+        key = BACKSPACE_KEY_VALUE;
+      }
+      dispatchKeyEventOrEnqueue(key);
+    }
+
+    return super.commitText(text, newCursorPosition);
+  }
+
+  @Override
+  public boolean deleteSurroundingText(int beforeLength, int afterLength) {
+    dispatchKeyEvent(BACKSPACE_KEY_VALUE);
+    return super.deleteSurroundingText(beforeLength, afterLength);
+  }
+
+  // Called by SwiftKey when cursor at beginning of input when there is a delete
+  // or when enter is pressed anywhere in the text. Whereas stock Android Keyboard calls
+  // {@link InputConnection#deleteSurroundingText} & {@link InputConnection#commitText}
+  // in each case, respectively.
+  @Override
+  public boolean sendKeyEvent(KeyEvent event) {
+    if(event.getAction() == KeyEvent.ACTION_DOWN) {
+      if (event.getKeyCode() == KeyEvent.KEYCODE_DEL) {
+        dispatchKeyEvent(BACKSPACE_KEY_VALUE);
+      } else if(event.getKeyCode() == KeyEvent.KEYCODE_ENTER) {
+        dispatchKeyEvent(ENTER_KEY_VALUE);
+      }
+    }
+    return super.sendKeyEvent(event);
+  }
+
+  private void dispatchKeyEventOrEnqueue(String key) {
+    if (mIsBatchEdit) {
+      mKey = key;
+    } else {
+      dispatchKeyEvent(key);
+    }
+  }
+
+  private void dispatchKeyEvent(String key) {
+    if (key.equals(NEWLINE_RAW_VALUE)) {
+      key = ENTER_KEY_VALUE;
+    }
+    mEventDispatcher.dispatchEvent(
+        new ReactTextInputKeyPressEvent(
+            mEditText.getId(),
+            key));
+  }
+}

--- a/android/src/main/java/com/reactlibrary/ReactTextChangedEvent.java
+++ b/android/src/main/java/com/reactlibrary/ReactTextChangedEvent.java
@@ -1,0 +1,54 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+package com.reactlibrary;
+
+import com.facebook.react.bridge.Arguments;
+import com.facebook.react.bridge.WritableMap;
+import com.facebook.react.uimanager.events.Event;
+import com.facebook.react.uimanager.events.RCTEventEmitter;
+
+/**
+ * Event emitted by EditText native view when text changes.
+ * VisibleForTesting from {@link TextInputEventsTestCase}.
+ */
+public class ReactTextChangedEvent extends Event<ReactTextChangedEvent> {
+
+  public static final String EVENT_NAME = "topChange";
+
+  private String mText;
+  private int mEventCount;
+
+  public ReactTextChangedEvent(
+      int viewId,
+      String text,
+      int eventCount) {
+    super(viewId);
+    mText = text;
+    mEventCount = eventCount;
+  }
+
+  @Override
+  public String getEventName() {
+    return EVENT_NAME;
+  }
+
+  @Override
+  public void dispatch(RCTEventEmitter rctEventEmitter) {
+    rctEventEmitter.receiveEvent(getViewTag(), getEventName(), serializeEventData());
+  }
+
+  private WritableMap serializeEventData() {
+    WritableMap eventData = Arguments.createMap();
+    eventData.putString("text", mText);
+    eventData.putInt("eventCount", mEventCount);
+    eventData.putInt("target", getViewTag());
+    return eventData;
+  }
+}

--- a/android/src/main/java/com/reactlibrary/ReactTextInputBlurEvent.java
+++ b/android/src/main/java/com/reactlibrary/ReactTextInputBlurEvent.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+package com.reactlibrary;
+
+import com.facebook.react.bridge.Arguments;
+import com.facebook.react.bridge.WritableMap;
+import com.facebook.react.uimanager.events.Event;
+import com.facebook.react.uimanager.events.RCTEventEmitter;
+
+/**
+ * Event emitted by EditText native view when it loses focus.
+ */
+/* package */ class ReactTextInputBlurEvent extends Event<ReactTextInputBlurEvent> {
+
+  private static final String EVENT_NAME = "topBlur";
+
+  public ReactTextInputBlurEvent(int viewId) {
+    super(viewId);
+  }
+
+  @Override
+  public String getEventName() {
+    return EVENT_NAME;
+  }
+
+  @Override
+  public boolean canCoalesce() {
+    return false;
+  }
+
+  @Override
+  public void dispatch(RCTEventEmitter rctEventEmitter) {
+    rctEventEmitter.receiveEvent(getViewTag(), getEventName(), serializeEventData());
+  }
+
+  private WritableMap serializeEventData() {
+    WritableMap eventData = Arguments.createMap();
+    eventData.putInt("target", getViewTag());
+    return eventData;
+  }
+}

--- a/android/src/main/java/com/reactlibrary/ReactTextInputEndEditingEvent.java
+++ b/android/src/main/java/com/reactlibrary/ReactTextInputEndEditingEvent.java
@@ -1,0 +1,55 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+package com.reactlibrary;
+
+import com.facebook.react.bridge.Arguments;
+import com.facebook.react.bridge.WritableMap;
+import com.facebook.react.uimanager.events.Event;
+import com.facebook.react.uimanager.events.RCTEventEmitter;
+
+/**
+ * Event emitted by EditText native view when text editing ends,
+ * because of the user leaving the text input.
+ */
+class ReactTextInputEndEditingEvent extends Event<ReactTextInputEndEditingEvent> {
+
+  private static final String EVENT_NAME = "topEndEditing";
+
+  private String mText;
+
+  public ReactTextInputEndEditingEvent(
+      int viewId,
+      String text) {
+    super(viewId);
+    mText = text;
+  }
+
+  @Override
+  public String getEventName() {
+    return EVENT_NAME;
+  }
+
+  @Override
+  public boolean canCoalesce() {
+    return false;
+  }
+
+  @Override
+  public void dispatch(RCTEventEmitter rctEventEmitter) {
+    rctEventEmitter.receiveEvent(getViewTag(), getEventName(), serializeEventData());
+  }
+
+  private WritableMap serializeEventData() {
+    WritableMap eventData = Arguments.createMap();
+    eventData.putInt("target", getViewTag());
+    eventData.putString("text", mText);
+    return eventData;
+  }
+}

--- a/android/src/main/java/com/reactlibrary/ReactTextInputEvent.java
+++ b/android/src/main/java/com/reactlibrary/ReactTextInputEvent.java
@@ -1,0 +1,72 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+package com.reactlibrary;
+
+import com.facebook.react.bridge.Arguments;
+import com.facebook.react.bridge.WritableMap;
+import com.facebook.react.uimanager.events.Event;
+import com.facebook.react.uimanager.events.RCTEventEmitter;
+
+/**
+ * Event emitted by EditText native view when text changes.
+ * VisibleForTesting from {@link TextInputEventsTestCase}.
+ */
+public class ReactTextInputEvent extends Event<ReactTextInputEvent> {
+
+  public static final String EVENT_NAME = "topTextInput";
+
+  private String mText;
+  private String mPreviousText;
+  private int mRangeStart;
+  private int mRangeEnd;
+
+  public ReactTextInputEvent(
+      int viewId,
+      String text,
+      String previousText,
+      int rangeStart,
+      int rangeEnd) {
+    super(viewId);
+    mText = text;
+    mPreviousText = previousText;
+    mRangeStart = rangeStart;
+    mRangeEnd = rangeEnd;
+  }
+
+  @Override
+  public String getEventName() {
+    return EVENT_NAME;
+  }
+
+  @Override
+  public boolean canCoalesce() {
+    // We don't want to miss any textinput event, as event data is incremental.
+    return false;
+  }
+
+  @Override
+  public void dispatch(RCTEventEmitter rctEventEmitter) {
+    rctEventEmitter.receiveEvent(getViewTag(), getEventName(), serializeEventData());
+  }
+
+  private WritableMap serializeEventData() {
+    WritableMap eventData = Arguments.createMap();
+    WritableMap range = Arguments.createMap();
+    range.putDouble("start", mRangeStart);
+    range.putDouble("end", mRangeEnd);
+
+    eventData.putString("text", mText);
+    eventData.putString("previousText", mPreviousText);
+    eventData.putMap("range", range);
+
+    eventData.putInt("target", getViewTag());
+    return eventData;
+  }
+}

--- a/android/src/main/java/com/reactlibrary/ReactTextInputFocusEvent.java
+++ b/android/src/main/java/com/reactlibrary/ReactTextInputFocusEvent.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+package com.reactlibrary;
+
+import com.facebook.react.bridge.Arguments;
+import com.facebook.react.bridge.WritableMap;
+import com.facebook.react.uimanager.events.Event;
+import com.facebook.react.uimanager.events.RCTEventEmitter;
+
+/**
+ * Event emitted by EditText native view when it receives focus.
+ */
+/* package */ class ReactTextInputFocusEvent extends Event<ReactTextInputFocusEvent> {
+
+  private static final String EVENT_NAME = "topFocus";
+
+  public ReactTextInputFocusEvent(int viewId) {
+    super(viewId);
+  }
+
+  @Override
+  public String getEventName() {
+    return EVENT_NAME;
+  }
+
+  @Override
+  public boolean canCoalesce() {
+    return false;
+  }
+
+  @Override
+  public void dispatch(RCTEventEmitter rctEventEmitter) {
+    rctEventEmitter.receiveEvent(getViewTag(), getEventName(), serializeEventData());
+  }
+
+  private WritableMap serializeEventData() {
+    WritableMap eventData = Arguments.createMap();
+    eventData.putInt("target", getViewTag());
+    return eventData;
+  }
+}

--- a/android/src/main/java/com/reactlibrary/ReactTextInputKeyPressEvent.java
+++ b/android/src/main/java/com/reactlibrary/ReactTextInputKeyPressEvent.java
@@ -1,0 +1,53 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+package com.reactlibrary;
+
+import com.facebook.react.bridge.Arguments;
+import com.facebook.react.bridge.WritableMap;
+import com.facebook.react.uimanager.events.Event;
+import com.facebook.react.uimanager.events.RCTEventEmitter;
+
+/**
+ * Event emitted by EditText native view when key pressed
+ */
+public class ReactTextInputKeyPressEvent extends Event<ReactTextInputEvent> {
+
+  public static final String EVENT_NAME = "topKeyPress";
+
+  private String mKey;
+
+  ReactTextInputKeyPressEvent(int viewId, final String key) {
+    super(viewId);
+    mKey = key;
+  }
+
+  @Override
+  public String getEventName() {
+    return EVENT_NAME;
+  }
+
+  @Override
+  public boolean canCoalesce() {
+    // We don't want to miss any textinput event, as event data is incremental.
+    return false;
+  }
+
+  @Override
+  public void dispatch(RCTEventEmitter rctEventEmitter) {
+    rctEventEmitter.receiveEvent(getViewTag(), getEventName(), serializeEventData());
+  }
+
+  private WritableMap serializeEventData() {
+    WritableMap eventData = Arguments.createMap();
+    eventData.putString("key", mKey);
+
+    return eventData;
+  }
+}

--- a/android/src/main/java/com/reactlibrary/ReactTextInputLocalData.java
+++ b/android/src/main/java/com/reactlibrary/ReactTextInputLocalData.java
@@ -1,0 +1,51 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+package com.reactlibrary;
+
+import android.os.Build;
+import android.text.SpannableStringBuilder;
+import android.util.TypedValue;
+import android.widget.EditText;
+
+/** Local state bearer for EditText instance. */
+public final class ReactTextInputLocalData {
+
+  private final SpannableStringBuilder mText;
+  private final float mTextSize;
+  private final int mMinLines;
+  private final int mMaxLines;
+  private final int mInputType;
+  private final int mBreakStrategy;
+
+  public ReactTextInputLocalData(EditText editText) {
+    mText = new SpannableStringBuilder(editText.getText());
+    mTextSize = editText.getTextSize();
+    mMinLines = editText.getMinLines();
+    mMaxLines = editText.getMaxLines();
+    mInputType = editText.getInputType();
+
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+      mBreakStrategy = editText.getBreakStrategy();
+    } else {
+      mBreakStrategy = 0;
+    }
+  }
+
+  public void apply(EditText editText) {
+    editText.setText(mText);
+    editText.setTextSize(TypedValue.COMPLEX_UNIT_PX, mTextSize);
+    editText.setMinLines(mMinLines);
+    editText.setMaxLines(mMaxLines);
+    editText.setInputType(mInputType);
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+      editText.setBreakStrategy(mBreakStrategy);
+    }
+  }
+}

--- a/android/src/main/java/com/reactlibrary/ReactTextInputSelectionEvent.java
+++ b/android/src/main/java/com/reactlibrary/ReactTextInputSelectionEvent.java
@@ -1,0 +1,57 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+package com.reactlibrary;
+
+import com.facebook.react.bridge.Arguments;
+import com.facebook.react.bridge.WritableMap;
+import com.facebook.react.uimanager.events.Event;
+import com.facebook.react.uimanager.events.RCTEventEmitter;
+
+/**
+ * Event emitted by EditText native view when the text selection changes.
+ */
+/* package */ class ReactTextInputSelectionEvent
+    extends Event<ReactTextInputSelectionEvent> {
+
+  private static final String EVENT_NAME = "topSelectionChange";
+
+  private int mSelectionStart;
+  private int mSelectionEnd;
+
+  public ReactTextInputSelectionEvent(
+      int viewId,
+      int selectionStart,
+      int selectionEnd) {
+    super(viewId);
+    mSelectionStart = selectionStart;
+    mSelectionEnd = selectionEnd;
+  }
+
+  @Override
+  public String getEventName() {
+    return EVENT_NAME;
+  }
+
+  @Override
+  public void dispatch(RCTEventEmitter rctEventEmitter) {
+    rctEventEmitter.receiveEvent(getViewTag(), getEventName(), serializeEventData());
+  }
+
+  private WritableMap serializeEventData() {
+    WritableMap eventData = Arguments.createMap();
+
+    WritableMap selectionData = Arguments.createMap();
+    selectionData.putInt("end", mSelectionEnd);
+    selectionData.putInt("start", mSelectionStart);
+
+    eventData.putMap("selection", selectionData);
+    return eventData;
+  }
+}

--- a/android/src/main/java/com/reactlibrary/ReactTextInputShadowNode.java
+++ b/android/src/main/java/com/reactlibrary/ReactTextInputShadowNode.java
@@ -1,0 +1,185 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+package com.reactlibrary;
+
+import android.os.Build;
+import android.text.Layout;
+import android.view.ViewGroup;
+import android.widget.EditText;
+import com.facebook.infer.annotation.Assertions;
+import com.facebook.react.bridge.JSApplicationIllegalArgumentException;
+import com.facebook.react.common.annotations.VisibleForTesting;
+import com.facebook.react.uimanager.Spacing;
+import com.facebook.react.uimanager.ThemedReactContext;
+import com.facebook.react.uimanager.UIViewOperationQueue;
+import com.facebook.react.uimanager.annotations.ReactProp;
+import com.facebook.react.views.text.ReactBaseTextShadowNode;
+import com.facebook.react.views.text.ReactTextUpdate;
+import com.facebook.react.views.view.MeasureUtil;
+import com.facebook.yoga.YogaMeasureFunction;
+import com.facebook.yoga.YogaMeasureMode;
+import com.facebook.yoga.YogaMeasureOutput;
+import com.facebook.yoga.YogaNode;
+import javax.annotation.Nullable;
+
+@VisibleForTesting
+public class ReactTextInputShadowNode extends ReactBaseTextShadowNode
+    implements YogaMeasureFunction {
+
+  private int mMostRecentEventCount = UNSET;
+  private @Nullable EditText mDummyEditText;
+  private @Nullable ReactTextInputLocalData mLocalData;
+
+  @VisibleForTesting public static final String PROP_TEXT = "text";
+
+  // Represents the {@code text} property only, not possible nested content.
+  private @Nullable String mText = null;
+
+  public ReactTextInputShadowNode() {
+    mTextBreakStrategy = (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) ?
+        0 : Layout.BREAK_STRATEGY_SIMPLE;
+
+    setMeasureFunction(this);
+  }
+
+  @Override
+  public void setThemedContext(ThemedReactContext themedContext) {
+    super.setThemedContext(themedContext);
+
+    // {@code EditText} has by default a border at the bottom of its view
+    // called "underline". To have a native look and feel of the TextEdit
+    // we have to preserve it at least by default.
+    // The border (underline) has its padding set by the background image
+    // provided by the system (which vary a lot among versions and vendors
+    // of Android), and it cannot be changed.
+    // So, we have to enforce it as a default padding.
+    // TODO #7120264: Cache this stuff better.
+    EditText editText = new EditText(getThemedContext());
+    setDefaultPadding(Spacing.START, editText.getPaddingStart());
+    setDefaultPadding(Spacing.TOP, editText.getPaddingTop());
+    setDefaultPadding(Spacing.END, editText.getPaddingEnd());
+    setDefaultPadding(Spacing.BOTTOM, editText.getPaddingBottom());
+
+    mDummyEditText = editText;
+
+    // We must measure the EditText without paddings, so we have to reset them.
+    mDummyEditText.setPadding(0, 0, 0, 0);
+
+    // This is needed to fix an android bug since 4.4.3 which will throw an NPE in measure,
+    // setting the layoutParams fixes it: https://code.google.com/p/android/issues/detail?id=75877
+    mDummyEditText.setLayoutParams(
+        new ViewGroup.LayoutParams(
+            ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT));
+  }
+
+  @Override
+  public long measure(
+      YogaNode node,
+      float width,
+      YogaMeasureMode widthMode,
+      float height,
+      YogaMeasureMode heightMode) {
+    // measure() should never be called before setThemedContext()
+    EditText editText = Assertions.assertNotNull(mDummyEditText);
+
+    if (mLocalData == null) {
+      // No local data, no intrinsic size.
+      return YogaMeasureOutput.make(0, 0);
+    }
+
+    mLocalData.apply(editText);
+
+    editText.measure(
+        MeasureUtil.getMeasureSpec(width, widthMode),
+        MeasureUtil.getMeasureSpec(height, heightMode));
+
+    return YogaMeasureOutput.make(editText.getMeasuredWidth(), editText.getMeasuredHeight());
+  }
+
+  @Override
+  public boolean isVirtualAnchor() {
+    return true;
+  }
+
+  @Override
+  public boolean isYogaLeafNode() {
+    return true;
+  }
+
+  @Override
+  public void setLocalData(Object data) {
+    Assertions.assertCondition(data instanceof ReactTextInputLocalData);
+    mLocalData = (ReactTextInputLocalData) data;
+
+    // Telling to Yoga that the node should be remeasured on next layout pass.
+    dirty();
+
+    // Note: We should NOT mark the node updated (by calling {@code markUpdated}) here
+    // because the state remains the same.
+  }
+
+  @ReactProp(name = "mostRecentEventCount")
+  public void setMostRecentEventCount(int mostRecentEventCount) {
+    mMostRecentEventCount = mostRecentEventCount;
+  }
+
+  @ReactProp(name = PROP_TEXT)
+  public void setText(@Nullable String text) {
+    mText = text;
+    markUpdated();
+  }
+
+  public @Nullable String getText() {
+    return mText;
+  }
+
+  @Override
+  public void setTextBreakStrategy(@Nullable String textBreakStrategy) {
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
+      return;
+    }
+
+    if (textBreakStrategy == null || "simple".equals(textBreakStrategy)) {
+      mTextBreakStrategy = Layout.BREAK_STRATEGY_SIMPLE;
+    } else if ("highQuality".equals(textBreakStrategy)) {
+      mTextBreakStrategy = Layout.BREAK_STRATEGY_HIGH_QUALITY;
+    } else if ("balanced".equals(textBreakStrategy)) {
+      mTextBreakStrategy = Layout.BREAK_STRATEGY_BALANCED;
+    } else {
+      throw new JSApplicationIllegalArgumentException("Invalid textBreakStrategy: " + textBreakStrategy);
+    }
+  }
+
+  @Override
+  public void onCollectExtraUpdates(UIViewOperationQueue uiViewOperationQueue) {
+    super.onCollectExtraUpdates(uiViewOperationQueue);
+
+    if (mMostRecentEventCount != UNSET) {
+      ReactTextUpdate reactTextUpdate =
+          new ReactTextUpdate(
+              spannedFromShadowNode(this, getText()),
+              mMostRecentEventCount,
+              mContainsImages,
+              getPadding(Spacing.LEFT),
+              getPadding(Spacing.TOP),
+              getPadding(Spacing.RIGHT),
+              getPadding(Spacing.BOTTOM),
+              mTextAlign,
+              mTextBreakStrategy);
+      uiViewOperationQueue.enqueueUpdateExtraData(getReactTag(), reactTextUpdate);
+    }
+  }
+
+  @Override
+  public void setPadding(int spacingType, float padding) {
+    super.setPadding(spacingType, padding);
+    markUpdated();
+  }
+}

--- a/android/src/main/java/com/reactlibrary/ReactTextInputSubmitEditingEvent.java
+++ b/android/src/main/java/com/reactlibrary/ReactTextInputSubmitEditingEvent.java
@@ -1,0 +1,55 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+package com.reactlibrary;
+
+import com.facebook.react.bridge.Arguments;
+import com.facebook.react.bridge.WritableMap;
+import com.facebook.react.uimanager.events.Event;
+import com.facebook.react.uimanager.events.RCTEventEmitter;
+
+/**
+ * Event emitted by EditText native view when the user submits the text.
+ */
+/* package */ class ReactTextInputSubmitEditingEvent
+    extends Event<ReactTextInputSubmitEditingEvent> {
+
+  private static final String EVENT_NAME = "topSubmitEditing";
+
+  private String mText;
+
+  public ReactTextInputSubmitEditingEvent(
+      int viewId,
+      String text) {
+    super(viewId);
+    mText = text;
+  }
+
+  @Override
+  public String getEventName() {
+    return EVENT_NAME;
+  }
+
+  @Override
+  public boolean canCoalesce() {
+    return false;
+  }
+
+  @Override
+  public void dispatch(RCTEventEmitter rctEventEmitter) {
+    rctEventEmitter.receiveEvent(getViewTag(), getEventName(), serializeEventData());
+  }
+
+  private WritableMap serializeEventData() {
+    WritableMap eventData = Arguments.createMap();
+    eventData.putInt("target", getViewTag());
+    eventData.putString("text", mText);
+    return eventData;
+  }
+}

--- a/android/src/main/java/com/reactlibrary/ScrollWatcher.java
+++ b/android/src/main/java/com/reactlibrary/ScrollWatcher.java
@@ -1,0 +1,14 @@
+/**
+ * Copyright (c) 2016-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+package com.reactlibrary;
+
+public interface ScrollWatcher {
+  public void onScrollChanged(int horiz, int vert, int oldHoriz, int oldVert);
+}

--- a/android/src/main/java/com/reactlibrary/SelectionWatcher.java
+++ b/android/src/main/java/com/reactlibrary/SelectionWatcher.java
@@ -1,0 +1,18 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+package com.reactlibrary;
+
+/**
+ * Implement this interface to be informed of selection changes in the ReactTextEdit
+ * This is used by the ReactTextInputManager to forward events from the EditText to JS
+ */
+interface SelectionWatcher {
+  public void onSelectionChanged(int start, int end);
+}

--- a/package.json
+++ b/package.json
@@ -5,7 +5,11 @@
   "main": "index.js",
   "peerDependencies": {
     "react": ">=15.1 || >=16.0.0-alpha.6",
-    "react-native": ">=0.40"
+    "react-native": ">=0.40",
+    "react-timer-mixin": "^0.13.3",
+    "create-react-class": "^15.6.3",
+    "fbjs": "^0.8.16",
+    "prop-types": "^15.6.1"
   },
   "devDependencies": {
     "babel-jest": "20.0.3",

--- a/src/AutoCompleteTextView.js
+++ b/src/AutoCompleteTextView.js
@@ -1,35 +1,1022 @@
-import PropTypes from 'prop-types';
-import React from 'react'
-import { requireNativeComponent, View } from 'react-native';
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @providesModule TextInput
+ * @flow
+ * @format
+ */
+'use strict';
 
-class AutoCompleteTextView extends React.Component {
-  constructor(props) {
-    super(props);
-    this._onChange = this._onChange.bind(this);
-  }
-  _onChange(event: Event) {
-    if (!this.props.onTextChange) {
-      return;
-    }
-    this.props.onTextChange(event.nativeEvent.text);
-  }
-  render() {
-    return <RCTAutoCompleteTextView {...this.props} onChange={this._onChange} />;
-  }
-}
+const ColorPropType = require('react-native/Libraries/StyleSheet/ColorPropType');
+const DocumentSelectionState = require('react-native/Libraries/vendor/document/selection/DocumentSelectionState');
+const EventEmitter = require('react-native/Libraries/EventEmitter/RCTEventEmitter');
+const NativeMethodsMixin = require('react-native/Libraries/Renderer/shims/NativeMethodsMixin');
+const Platform = require('react-native/Libraries/Utilities/Platform');
+const React = require('react-native/Libraries/react-native/React');
+const createReactClass = require('create-react-class');
+const PropTypes = require('prop-types');
+const ReactNative = require('react-native/Libraries/Renderer/shims/ReactNative');
+const StyleSheet = require('react-native/Libraries/StyleSheet/StyleSheet');
+const Text = require('react-native/Libraries/Text/Text');
+const TextInputState = require('react-native/Libraries/Components/TextInput/TextInputState');
+/* $FlowFixMe(>=0.54.0 site=react_native_oss) This comment suppresses an error
+ * found when Flow v0.54 was deployed. To see the error delete this comment and
+ * run Flow. */
+const TimerMixin = require('react-timer-mixin');
+const TouchableWithoutFeedback = require('react-native/Libraries/Components/Touchable/TouchableWithoutFeedback');
+const UIManager = require('react-native/Libraries/ReactNative/UIManager');
+const ViewPropTypes = require('react-native/Libraries/Components/View/ViewPropTypes');
+const {ViewContextTypes} = require('react-native/Libraries/Components/View/ViewContext');
 
-AutoCompleteTextView.propTypes = {
-  dataSource: PropTypes.array.isRequired,
-  value: PropTypes.string.isRequired,
-  onTextChange: PropTypes.func.isRequired,
-  showDropDown: PropTypes.bool,
-  showDropDownArrow: PropTypes.bool,
-  hint: PropTypes.string,
-  ...View.propTypes
+/* $FlowFixMe(>=0.54.0 site=react_native_oss) This comment suppresses an error
+ * found when Flow v0.54 was deployed. To see the error delete this comment and
+ * run Flow. */
+const emptyFunction = require('fbjs/lib/emptyFunction');
+const invariant = require('fbjs/lib/invariant');
+const requireNativeComponent = require('react-native/Libraries/ReactNative/requireNativeComponent');
+/* $FlowFixMe(>=0.54.0 site=react_native_oss) This comment suppresses an error
+ * found when Flow v0.54 was deployed. To see the error delete this comment and
+ * run Flow. */
+const warning = require('fbjs/lib/warning');
+
+const onlyMultiline = {
+  onTextInput: true,
+  children: true,
 };
 
-var RCTAutoCompleteTextView = requireNativeComponent('RCTAutoCompleteTextView', AutoCompleteTextView, {
-  nativeOnly: {onChange: true}
+import type {ViewChildContext} from 'react-native/Libraries/Components/View/ViewContext';
+
+if (Platform.OS === 'android') {
+  var AndroidTextInput = requireNativeComponent('RCTAutoCompleteTextView', null);
+} else if (Platform.OS === 'ios') {
+  var RCTMultilineTextInputView = requireNativeComponent(
+    'RCTMultilineTextInputView',
+    null,
+  );
+  var RCTSinglelineTextInputView = requireNativeComponent(
+    'RCTSinglelineTextInputView',
+    null,
+  );
+}
+
+type Event = Object;
+type Selection = {
+  start: number,
+  end?: number,
+};
+
+const DataDetectorTypes = [
+  'phoneNumber',
+  'link',
+  'address',
+  'calendarEvent',
+  'none',
+  'all',
+];
+
+/**
+ * A foundational component for inputting text into the app via a
+ * keyboard. Props provide configurability for several features, such as
+ * auto-correction, auto-capitalization, placeholder text, and different keyboard
+ * types, such as a numeric keypad.
+ *
+ * The simplest use case is to plop down a `TextInput` and subscribe to the
+ * `onChangeText` events to read the user input. There are also other events,
+ * such as `onSubmitEditing` and `onFocus` that can be subscribed to. A simple
+ * example:
+ *
+ * ```ReactNativeWebPlayer
+ * import React, { Component } from 'react';
+ * import { AppRegistry, TextInput } from 'react-native';
+ *
+ * export default class UselessTextInput extends Component {
+ *   constructor(props) {
+ *     super(props);
+ *     this.state = { text: 'Useless Placeholder' };
+ *   }
+ *
+ *   render() {
+ *     return (
+ *       <TextInput
+ *         style={{height: 40, borderColor: 'gray', borderWidth: 1}}
+ *         onChangeText={(text) => this.setState({text})}
+ *         value={this.state.text}
+ *       />
+ *     );
+ *   }
+ * }
+ *
+ * // skip this line if using Create React Native App
+ * AppRegistry.registerComponent('AwesomeProject', () => UselessTextInput);
+ * ```
+ *
+ * Two methods exposed via the native element are .focus() and .blur() that
+ * will focus or blur the TextInput programmatically.
+ *
+ * Note that some props are only available with `multiline={true/false}`.
+ * Additionally, border styles that apply to only one side of the element
+ * (e.g., `borderBottomColor`, `borderLeftWidth`, etc.) will not be applied if
+ * `multiline=false`. To achieve the same effect, you can wrap your `TextInput`
+ * in a `View`:
+ *
+ * ```ReactNativeWebPlayer
+ * import React, { Component } from 'react';
+ * import { AppRegistry, View, TextInput } from 'react-native';
+ *
+ * class UselessTextInput extends Component {
+ *   render() {
+ *     return (
+ *       <TextInput
+ *         {...this.props} // Inherit any props passed to it; e.g., multiline, numberOfLines below
+ *         editable = {true}
+ *         maxLength = {40}
+ *       />
+ *     );
+ *   }
+ * }
+ *
+ * export default class UselessTextInputMultiline extends Component {
+ *   constructor(props) {
+ *     super(props);
+ *     this.state = {
+ *       text: 'Useless Multiline Placeholder',
+ *     };
+ *   }
+ *
+ *   // If you type something in the text box that is a color, the background will change to that
+ *   // color.
+ *   render() {
+ *     return (
+ *      <View style={{
+ *        backgroundColor: this.state.text,
+ *        borderBottomColor: '#000000',
+ *        borderBottomWidth: 1 }}
+ *      >
+ *        <UselessTextInput
+ *          multiline = {true}
+ *          numberOfLines = {4}
+ *          onChangeText={(text) => this.setState({text})}
+ *          value={this.state.text}
+ *        />
+ *      </View>
+ *     );
+ *   }
+ * }
+ *
+ * // skip these lines if using Create React Native App
+ * AppRegistry.registerComponent(
+ *  'AwesomeProject',
+ *  () => UselessTextInputMultiline
+ * );
+ * ```
+ *
+ * `TextInput` has by default a border at the bottom of its view. This border
+ * has its padding set by the background image provided by the system, and it
+ * cannot be changed. Solutions to avoid this is to either not set height
+ * explicitly, case in which the system will take care of displaying the border
+ * in the correct position, or to not display the border by setting
+ * `underlineColorAndroid` to transparent.
+ *
+ * Note that on Android performing text selection in input can change
+ * app's activity `windowSoftInputMode` param to `adjustResize`.
+ * This may cause issues with components that have position: 'absolute'
+ * while keyboard is active. To avoid this behavior either specify `windowSoftInputMode`
+ * in AndroidManifest.xml ( https://developer.android.com/guide/topics/manifest/activity-element.html )
+ * or control this param programmatically with native code.
+ *
+ */
+
+const AutoCompleteTextView = createReactClass({
+  displayName: 'AutoCompleteTextView',
+  statics: {
+    /* TODO(brentvatne) docs are needed for this */
+    State: TextInputState,
+  },
+
+  propTypes: {
+    /** start my */
+    dataSource: PropTypes.array.isRequired,
+    threshold: PropTypes.number,
+    /** end */
+    ...ViewPropTypes,
+    /**
+     * Can tell `TextInput` to automatically capitalize certain characters.
+     *
+     * - `characters`: all characters.
+     * - `words`: first letter of each word.
+     * - `sentences`: first letter of each sentence (*default*).
+     * - `none`: don't auto capitalize anything.
+     */
+    autoCapitalize: PropTypes.oneOf([
+      'none',
+      'sentences',
+      'words',
+      'characters',
+    ]),
+    /**
+     * If `false`, disables auto-correct. The default value is `true`.
+     */
+    autoCorrect: PropTypes.bool,
+    /**
+     * If `false`, disables spell-check style (i.e. red underlines).
+     * The default value is inherited from `autoCorrect`.
+     * @platform ios
+     */
+    spellCheck: PropTypes.bool,
+    /**
+     * If `true`, focuses the input on `componentDidMount`.
+     * The default value is `false`.
+     */
+    autoFocus: PropTypes.bool,
+    /**
+     * Specifies whether fonts should scale to respect Text Size accessibility settings. The
+     * default is `true`.
+     */
+    allowFontScaling: PropTypes.bool,
+    /**
+     * If `false`, text is not editable. The default value is `true`.
+     */
+    editable: PropTypes.bool,
+    /**
+     * Determines which keyboard to open, e.g.`numeric`.
+     *
+     * The following values work across platforms:
+     *
+     * - `default`
+     * - `numeric`
+     * - `email-address`
+     * - `phone-pad`
+     *
+     * *iOS Only*
+     *
+     * The following values work on iOS only:
+     *
+     * - `ascii-capable`
+     * - `numbers-and-punctuation`
+     * - `url`
+     * - `number-pad`
+     * - `name-phone-pad`
+     * - `decimal-pad`
+     * - `twitter`
+     * - `web-search`
+     *
+     * *Android Only*
+     *
+     * The following values work on Android only:
+     *
+     * - `visible-password`
+     */
+    keyboardType: PropTypes.oneOf([
+      // Cross-platform
+      'default',
+      'email-address',
+      'numeric',
+      'phone-pad',
+      // iOS-only
+      'ascii-capable',
+      'numbers-and-punctuation',
+      'url',
+      'number-pad',
+      'name-phone-pad',
+      'decimal-pad',
+      'twitter',
+      'web-search',
+      // Android-only
+      'visible-password',
+    ]),
+    /**
+     * Determines the color of the keyboard.
+     * @platform ios
+     */
+    keyboardAppearance: PropTypes.oneOf(['default', 'light', 'dark']),
+    /**
+     * Determines how the return key should look. On Android you can also use
+     * `returnKeyLabel`.
+     *
+     * *Cross platform*
+     *
+     * The following values work across platforms:
+     *
+     * - `done`
+     * - `go`
+     * - `next`
+     * - `search`
+     * - `send`
+     *
+     * *Android Only*
+     *
+     * The following values work on Android only:
+     *
+     * - `none`
+     * - `previous`
+     *
+     * *iOS Only*
+     *
+     * The following values work on iOS only:
+     *
+     * - `default`
+     * - `emergency-call`
+     * - `google`
+     * - `join`
+     * - `route`
+     * - `yahoo`
+     */
+    returnKeyType: PropTypes.oneOf([
+      // Cross-platform
+      'done',
+      'go',
+      'next',
+      'search',
+      'send',
+      // Android-only
+      'none',
+      'previous',
+      // iOS-only
+      'default',
+      'emergency-call',
+      'google',
+      'join',
+      'route',
+      'yahoo',
+    ]),
+    /**
+     * Sets the return key to the label. Use it instead of `returnKeyType`.
+     * @platform android
+     */
+    returnKeyLabel: PropTypes.string,
+    /**
+     * Limits the maximum number of characters that can be entered. Use this
+     * instead of implementing the logic in JS to avoid flicker.
+     */
+    maxLength: PropTypes.number,
+    /**
+     * Sets the number of lines for a `TextInput`. Use it with multiline set to
+     * `true` to be able to fill the lines.
+     * @platform android
+     */
+    numberOfLines: PropTypes.number,
+    /**
+     * When `false`, if there is a small amount of space available around a text input
+     * (e.g. landscape orientation on a phone), the OS may choose to have the user edit
+     * the text inside of a full screen text input mode. When `true`, this feature is
+     * disabled and users will always edit the text directly inside of the text input.
+     * Defaults to `false`.
+     * @platform android
+     */
+    disableFullscreenUI: PropTypes.bool,
+    /**
+     * If `true`, the keyboard disables the return key when there is no text and
+     * automatically enables it when there is text. The default value is `false`.
+     * @platform ios
+     */
+    enablesReturnKeyAutomatically: PropTypes.bool,
+    /**
+     * If `true`, the text input can be multiple lines.
+     * The default value is `false`.
+     */
+    multiline: PropTypes.bool,
+    /**
+     * Set text break strategy on Android API Level 23+, possible values are `simple`, `highQuality`, `balanced`
+     * The default value is `simple`.
+     * @platform android
+     */
+    textBreakStrategy: PropTypes.oneOf(['simple', 'highQuality', 'balanced']),
+    /**
+     * Callback that is called when the text input is blurred.
+     */
+    onBlur: PropTypes.func,
+    /**
+     * Callback that is called when the text input is focused.
+     */
+    onFocus: PropTypes.func,
+    /**
+     * Callback that is called when the text input's text changes.
+     */
+    onChange: PropTypes.func,
+    /**
+     * Callback that is called when the text input's text changes.
+     * Changed text is passed as an argument to the callback handler.
+     */
+    onChangeText: PropTypes.func,
+    /**
+     * Callback that is called when the text input's content size changes.
+     * This will be called with
+     * `{ nativeEvent: { contentSize: { width, height } } }`.
+     *
+     * Only called for multiline text inputs.
+     */
+    onContentSizeChange: PropTypes.func,
+    /**
+     * Callback that is called when text input ends.
+     */
+    onEndEditing: PropTypes.func,
+    /**
+     * Callback that is called when the text input selection is changed.
+     * This will be called with
+     * `{ nativeEvent: { selection: { start, end } } }`.
+     */
+    onSelectionChange: PropTypes.func,
+    /**
+     * Callback that is called when the text input's submit button is pressed.
+     * Invalid if `multiline={true}` is specified.
+     */
+    onSubmitEditing: PropTypes.func,
+    /**
+     * Callback that is called when a key is pressed.
+     * This will be called with `{ nativeEvent: { key: keyValue } }`
+     * where `keyValue` is `'Enter'` or `'Backspace'` for respective keys and
+     * the typed-in character otherwise including `' '` for space.
+     * Fires before `onChange` callbacks.
+     */
+    onKeyPress: PropTypes.func,
+    /**
+     * Invoked on mount and layout changes with `{x, y, width, height}`.
+     */
+    onLayout: PropTypes.func,
+    /**
+     * Invoked on content scroll with `{ nativeEvent: { contentOffset: { x, y } } }`.
+     * May also contain other properties from ScrollEvent but on Android contentSize
+     * is not provided for performance reasons.
+     */
+    onScroll: PropTypes.func,
+    /**
+     * The string that will be rendered before text input has been entered.
+     */
+    placeholder: PropTypes.string,
+    /**
+     * The text color of the placeholder string.
+     */
+    placeholderTextColor: ColorPropType,
+    /**
+     * If `true`, the text input obscures the text entered so that sensitive text
+     * like passwords stay secure. The default value is `false`. Does not work with 'multiline={true}'.
+     */
+    secureTextEntry: PropTypes.bool,
+    /**
+     * The highlight and cursor color of the text input.
+     */
+    selectionColor: ColorPropType,
+    /**
+     * An instance of `DocumentSelectionState`, this is some state that is responsible for
+     * maintaining selection information for a document.
+     *
+     * Some functionality that can be performed with this instance is:
+     *
+     * - `blur()`
+     * - `focus()`
+     * - `update()`
+     *
+     * > You can reference `DocumentSelectionState` in
+     * > [`vendor/document/selection/DocumentSelectionState.js`](https://github.com/facebook/react-native/blob/master/Libraries/vendor/document/selection/DocumentSelectionState.js)
+     *
+     * @platform ios
+     */
+    selectionState: PropTypes.instanceOf(DocumentSelectionState),
+    /**
+     * The start and end of the text input's selection. Set start and end to
+     * the same value to position the cursor.
+     */
+    selection: PropTypes.shape({
+      start: PropTypes.number.isRequired,
+      end: PropTypes.number,
+    }),
+    /**
+     * The value to show for the text input. `TextInput` is a controlled
+     * component, which means the native value will be forced to match this
+     * value prop if provided. For most uses, this works great, but in some
+     * cases this may cause flickering - one common cause is preventing edits
+     * by keeping value the same. In addition to simply setting the same value,
+     * either set `editable={false}`, or set/update `maxLength` to prevent
+     * unwanted edits without flicker.
+     */
+    value: PropTypes.string,
+    /**
+     * Provides an initial value that will change when the user starts typing.
+     * Useful for simple use-cases where you do not want to deal with listening
+     * to events and updating the value prop to keep the controlled state in sync.
+     */
+    defaultValue: PropTypes.string,
+    /**
+     * When the clear button should appear on the right side of the text view.
+     * This property is supported only for single-line TextInput component.
+     * @platform ios
+     */
+    clearButtonMode: PropTypes.oneOf([
+      'never',
+      'while-editing',
+      'unless-editing',
+      'always',
+    ]),
+    /**
+     * If `true`, clears the text field automatically when editing begins.
+     * @platform ios
+     */
+    clearTextOnFocus: PropTypes.bool,
+    /**
+     * If `true`, all text will automatically be selected on focus.
+     */
+    selectTextOnFocus: PropTypes.bool,
+    /**
+     * If `true`, the text field will blur when submitted.
+     * The default value is true for single-line fields and false for
+     * multiline fields. Note that for multiline fields, setting `blurOnSubmit`
+     * to `true` means that pressing return will blur the field and trigger the
+     * `onSubmitEditing` event instead of inserting a newline into the field.
+     */
+    blurOnSubmit: PropTypes.bool,
+    /**
+     * Note that not all Text styles are supported, an incomplete list of what is not supported includes:
+     *
+     * - `borderLeftWidth`
+     * - `borderTopWidth`
+     * - `borderRightWidth`
+     * - `borderBottomWidth`
+     * - `borderTopLeftRadius`
+     * - `borderTopRightRadius`
+     * - `borderBottomRightRadius`
+     * - `borderBottomLeftRadius`
+     *
+     * see [Issue#7070](https://github.com/facebook/react-native/issues/7070)
+     * for more detail.
+     *
+     * [Styles](docs/style.html)
+     */
+    style: Text.propTypes.style,
+    /**
+     * The color of the `TextInput` underline.
+     * @platform android
+     */
+    underlineColorAndroid: ColorPropType,
+
+    /**
+     * If defined, the provided image resource will be rendered on the left.
+     * The image resource must be inside `/android/app/src/main/res/drawable` and referenced
+     * like
+     * ```
+     * <TextInput
+     *  inlineImageLeft='search_icon'
+     * />
+     * ```
+     * @platform android
+     */
+    inlineImageLeft: PropTypes.string,
+
+    /**
+     * Padding between the inline image, if any, and the text input itself.
+     * @platform android
+     */
+    inlineImagePadding: PropTypes.number,
+
+    /**
+     * Determines the types of data converted to clickable URLs in the text input.
+     * Only valid if `multiline={true}` and `editable={false}`.
+     * By default no data types are detected.
+     *
+     * You can provide one type or an array of many types.
+     *
+     * Possible values for `dataDetectorTypes` are:
+     *
+     * - `'phoneNumber'`
+     * - `'link'`
+     * - `'address'`
+     * - `'calendarEvent'`
+     * - `'none'`
+     * - `'all'`
+     *
+     * @platform ios
+     */
+    dataDetectorTypes: PropTypes.oneOfType([
+      PropTypes.oneOf(DataDetectorTypes),
+      PropTypes.arrayOf(PropTypes.oneOf(DataDetectorTypes)),
+    ]),
+    /**
+     * If `true`, caret is hidden. The default value is `false`.
+     * This property is supported only for single-line TextInput component on iOS.
+     */
+    caretHidden: PropTypes.bool,
+  },
+  getDefaultProps(): Object {
+    return {
+      allowFontScaling: true,
+    };
+  },
+  /**
+   * `NativeMethodsMixin` will look for this when invoking `setNativeProps`. We
+   * make `this` look like an actual native component class.
+   */
+  mixins: [NativeMethodsMixin, TimerMixin],
+
+  /**
+   * Returns `true` if the input is currently focused; `false` otherwise.
+   */
+  isFocused: function(): boolean {
+    return (
+      TextInputState.currentlyFocusedField() ===
+      ReactNative.findNodeHandle(this._inputRef)
+    );
+  },
+
+  _inputRef: (undefined: any),
+  _focusSubscription: (undefined: ?Function),
+  _lastNativeText: (undefined: ?string),
+  _lastNativeSelection: (undefined: ?Selection),
+
+  componentDidMount: function() {
+    this._lastNativeText = this.props.value;
+    if (!this.context.focusEmitter) {
+      if (this.props.autoFocus) {
+        this.requestAnimationFrame(this.focus);
+      }
+      return;
+    }
+    this._focusSubscription = this.context.focusEmitter.addListener(
+      'focus',
+      el => {
+        if (this === el) {
+          this.requestAnimationFrame(this.focus);
+        } else if (this.isFocused()) {
+          this.blur();
+        }
+      },
+    );
+    if (this.props.autoFocus) {
+      this.context.onFocusRequested(this);
+    }
+  },
+
+  componentWillUnmount: function() {
+    this._focusSubscription && this._focusSubscription.remove();
+    if (this.isFocused()) {
+      this.blur();
+    }
+  },
+
+  getChildContext(): ViewChildContext {
+    return {
+      isInAParentText: true,
+    };
+  },
+
+  childContextTypes: ViewContextTypes,
+
+  contextTypes: {
+    ...ViewContextTypes,
+    onFocusRequested: PropTypes.func,
+    focusEmitter: PropTypes.instanceOf(EventEmitter),
+  },
+
+  /**
+   * Removes all text from the `TextInput`.
+   */
+  clear: function() {
+    this.setNativeProps({text: ''});
+  },
+
+  render: function() {
+    if (Platform.OS === 'ios') {
+      return UIManager.RCTVirtualText
+        ? this._renderIOS()
+        : this._renderIOSLegacy();
+    } else if (Platform.OS === 'android') {
+      return this._renderAndroid();
+    }
+  },
+
+  _getText: function(): ?string {
+    return typeof this.props.value === 'string'
+      ? this.props.value
+      : typeof this.props.defaultValue === 'string'
+        ? this.props.defaultValue
+        : '';
+  },
+
+  _setNativeRef: function(ref: any) {
+    this._inputRef = ref;
+  },
+
+  _renderIOSLegacy: function() {
+    var textContainer;
+
+    var props = Object.assign({}, this.props);
+    props.style = [this.props.style];
+
+    if (props.selection && props.selection.end == null) {
+      props.selection = {
+        start: props.selection.start,
+        end: props.selection.start,
+      };
+    }
+
+    if (!props.multiline) {
+      if (__DEV__) {
+        for (var propKey in onlyMultiline) {
+          if (props[propKey]) {
+            const error = new Error(
+              'TextInput prop `' +
+                propKey +
+                '` is only supported with multiline.',
+            );
+            warning(false, '%s', error.stack);
+          }
+        }
+      }
+      textContainer = (
+        <RCTSinglelineTextInputView
+          ref={this._setNativeRef}
+          {...props}
+          onFocus={this._onFocus}
+          onBlur={this._onBlur}
+          onChange={this._onChange}
+          onSelectionChange={this._onSelectionChange}
+          onSelectionChangeShouldSetResponder={emptyFunction.thatReturnsTrue}
+          text={this._getText()}
+        />
+      );
+    } else {
+      var children = props.children;
+      var childCount = 0;
+      React.Children.forEach(children, () => ++childCount);
+      invariant(
+        !(props.value && childCount),
+        'Cannot specify both value and children.',
+      );
+      if (childCount >= 1) {
+        children = (
+          <Text style={props.style} allowFontScaling={props.allowFontScaling}>
+            {children}
+          </Text>
+        );
+      }
+      if (props.inputView) {
+        children = [children, props.inputView];
+      }
+      props.style.unshift(styles.multilineInput);
+      textContainer = (
+        <RCTMultilineTextInputView
+          ref={this._setNativeRef}
+          {...props}
+          children={children}
+          onFocus={this._onFocus}
+          onBlur={this._onBlur}
+          onChange={this._onChange}
+          onContentSizeChange={this.props.onContentSizeChange}
+          onSelectionChange={this._onSelectionChange}
+          onTextInput={this._onTextInput}
+          onSelectionChangeShouldSetResponder={emptyFunction.thatReturnsTrue}
+          text={this._getText()}
+          dataDetectorTypes={this.props.dataDetectorTypes}
+          onScroll={this._onScroll}
+        />
+      );
+    }
+
+    return (
+      <TouchableWithoutFeedback
+        onLayout={props.onLayout}
+        onPress={this._onPress}
+        rejectResponderTermination={true}
+        accessible={props.accessible}
+        accessibilityLabel={props.accessibilityLabel}
+        accessibilityTraits={props.accessibilityTraits}
+        nativeID={this.props.nativeID}
+        testID={props.testID}>
+        {textContainer}
+      </TouchableWithoutFeedback>
+    );
+  },
+
+  _renderIOS: function() {
+    var props = Object.assign({}, this.props);
+    props.style = [this.props.style];
+
+    if (props.selection && props.selection.end == null) {
+      props.selection = {
+        start: props.selection.start,
+        end: props.selection.start,
+      };
+    }
+
+    const RCTTextInputView = props.multiline
+      ? RCTMultilineTextInputView
+      : RCTSinglelineTextInputView;
+
+    if (props.multiline) {
+      props.style.unshift(styles.multilineInput);
+    }
+
+    const textContainer = (
+      <RCTTextInputView
+        ref={this._setNativeRef}
+        {...props}
+        onFocus={this._onFocus}
+        onBlur={this._onBlur}
+        onChange={this._onChange}
+        onContentSizeChange={this.props.onContentSizeChange}
+        onSelectionChange={this._onSelectionChange}
+        onTextInput={this._onTextInput}
+        onSelectionChangeShouldSetResponder={emptyFunction.thatReturnsTrue}
+        text={this._getText()}
+        dataDetectorTypes={this.props.dataDetectorTypes}
+        onScroll={this._onScroll}
+      />
+    );
+
+    return (
+      <TouchableWithoutFeedback
+        onLayout={props.onLayout}
+        onPress={this._onPress}
+        rejectResponderTermination={true}
+        accessible={props.accessible}
+        accessibilityLabel={props.accessibilityLabel}
+        accessibilityTraits={props.accessibilityTraits}
+        nativeID={this.props.nativeID}
+        testID={props.testID}>
+        {textContainer}
+      </TouchableWithoutFeedback>
+    );
+  },
+
+  _renderAndroid: function() {
+    const props = Object.assign({}, this.props);
+    props.style = [this.props.style];
+    props.autoCapitalize =
+      UIManager.AndroidTextInput.Constants.AutoCapitalizationType[
+        props.autoCapitalize || 'sentences'
+      ];
+    /* $FlowFixMe(>=0.53.0 site=react_native_fb,react_native_oss) This comment
+     * suppresses an error when upgrading Flow's support for React. To see the
+     * error delete this comment and run Flow. */
+    var children = this.props.children;
+    var childCount = 0;
+    React.Children.forEach(children, () => ++childCount);
+    invariant(
+      !(this.props.value && childCount),
+      'Cannot specify both value and children.',
+    );
+    if (childCount > 1) {
+      children = <Text>{children}</Text>;
+    }
+
+    if (props.selection && props.selection.end == null) {
+      props.selection = {
+        start: props.selection.start,
+        end: props.selection.start,
+      };
+    }
+
+    const textContainer = (
+      <AndroidTextInput
+        ref={this._setNativeRef}
+        {...props}
+        mostRecentEventCount={0}
+        onFocus={this._onFocus}
+        onBlur={this._onBlur}
+        onChange={this._onChange}
+        onSelectionChange={this._onSelectionChange}
+        onTextInput={this._onTextInput}
+        text={this._getText()}
+        children={children}
+        disableFullscreenUI={this.props.disableFullscreenUI}
+        textBreakStrategy={this.props.textBreakStrategy}
+        onScroll={this._onScroll}
+      />
+    );
+
+    return (
+      <TouchableWithoutFeedback
+        onLayout={this._onLayout}
+        onPress={this._onPress}
+        accessible={this.props.accessible}
+        accessibilityLabel={this.props.accessibilityLabel}
+        accessibilityComponentType={this.props.accessibilityComponentType}
+        nativeID={this.props.nativeID}
+        testID={this.props.testID}>
+        {textContainer}
+      </TouchableWithoutFeedback>
+    );
+  },
+
+  _onFocus: function(event: Event) {
+    if (this.props.onFocus) {
+      this.props.onFocus(event);
+    }
+
+    if (this.props.selectionState) {
+      this.props.selectionState.focus();
+    }
+  },
+
+  _onPress: function(event: Event) {
+    if (this.props.editable || this.props.editable === undefined) {
+      this.focus();
+    }
+  },
+
+  _onChange: function(event: Event) {
+    // Make sure to fire the mostRecentEventCount first so it is already set on
+    // native when the text value is set.
+    if (this._inputRef) {
+      this._inputRef.setNativeProps({
+        mostRecentEventCount: event.nativeEvent.eventCount,
+      });
+    }
+
+    var text = event.nativeEvent.text;
+    this.props.onChange && this.props.onChange(event);
+    this.props.onChangeText && this.props.onChangeText(text);
+
+    if (!this._inputRef) {
+      // calling `this.props.onChange` or `this.props.onChangeText`
+      // may clean up the input itself. Exits here.
+      return;
+    }
+
+    this._lastNativeText = text;
+    this.forceUpdate();
+  },
+
+  _onSelectionChange: function(event: Event) {
+    this.props.onSelectionChange && this.props.onSelectionChange(event);
+
+    if (!this._inputRef) {
+      // calling `this.props.onSelectionChange`
+      // may clean up the input itself. Exits here.
+      return;
+    }
+
+    this._lastNativeSelection = event.nativeEvent.selection;
+
+    if (this.props.selection || this.props.selectionState) {
+      this.forceUpdate();
+    }
+  },
+
+  componentDidUpdate: function() {
+    // This is necessary in case native updates the text and JS decides
+    // that the update should be ignored and we should stick with the value
+    // that we have in JS.
+    const nativeProps = {};
+
+    if (
+      this._lastNativeText !== this.props.value &&
+      typeof this.props.value === 'string'
+    ) {
+      nativeProps.text = this.props.value;
+    }
+
+    // Selection is also a controlled prop, if the native value doesn't match
+    // JS, update to the JS value.
+    const {selection} = this.props;
+    if (
+      this._lastNativeSelection &&
+      selection &&
+      (this._lastNativeSelection.start !== selection.start ||
+        this._lastNativeSelection.end !== selection.end)
+    ) {
+      nativeProps.selection = this.props.selection;
+    }
+
+    if (Object.keys(nativeProps).length > 0 && this._inputRef) {
+      this._inputRef.setNativeProps(nativeProps);
+    }
+
+    if (this.props.selectionState && selection) {
+      this.props.selectionState.update(selection.start, selection.end);
+    }
+  },
+
+  _onBlur: function(event: Event) {
+    this.blur();
+    if (this.props.onBlur) {
+      this.props.onBlur(event);
+    }
+
+    if (this.props.selectionState) {
+      this.props.selectionState.blur();
+    }
+  },
+
+  _onTextInput: function(event: Event) {
+    this.props.onTextInput && this.props.onTextInput(event);
+  },
+
+  _onScroll: function(event: Event) {
+    this.props.onScroll && this.props.onScroll(event);
+  },
 });
 
-export { AutoCompleteTextView }
+var styles = StyleSheet.create({
+  multilineInput: {
+    // This default top inset makes RCTMultilineTextInputView seem as close as possible
+    // to single-line RCTSinglelineTextInputView defaults, using the system defaults
+    // of font size 17 and a height of 31 points.
+    paddingTop: 5,
+  },
+});
+
+module.exports.AutoCompleteTextView = AutoCompleteTextView;


### PR DESCRIPTION
I tried hard to extend ReactEditText, as that has all the `multiline` and fix for the nasty bug where focus stays locked in the field. However it seems to block text change events which doesnt trigger the suggestions box.


Usage:

```
import React, { Component } from 'react'
import { View, TextInput, ScrollView } from 'react-native'
import { AutoCompleteTextView } from 'autocompletetextview'

export default class App extends Component {
    render() {
        return (
            <ScrollView contentContainerStyle={{ flex:1, justifyContent:'center', alignItems:'center' }} keyboardShouldPersistTaps="handled">
                <TextInput
                    style={{ height:60, width:200 }}
                    placeholder="react native out of the box" />
                <AutoCompleteTextView
                    style={{ height:60, width:200 }}
                    dataSource={['Noitidart', 'Raj', 'Banglore', 'Bangladesh', 'Bangkok', 'Goa', 'Not Today', 'Ark', 'Alley', 'Gmail']}
                    placeholder="type a message"
                    placeholderTextColor="rgba(255, 0, 0, 0.5)"
                    disableFullscreenUI
                    threshold={1}
                    selectTextOnFocus />
            </ScrollView>
        )
    }
}
```